### PR TITLE
Message store queries now return meta as well as message.

### DIFF
--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -35,6 +35,9 @@ class MessageStoreProxy:
 		meta_copy["name"] = name
 		return self.query(type, {}, meta_copy, single)
 
+	"""
+	Returns [message, meta] where message is the queried message and meta a dictionary of meta information. If single is false returns a list of these lists.
+	"""
 	def query(self, type, message_query = {}, meta_query = {}, single = False):
 		# assume meta is a dict, convert k/v to tuple pairs for ROS msg type
 
@@ -47,13 +50,15 @@ class MessageStoreProxy:
 
 		if response.messages is None:
 			messages = []
+			metas = []
 		else:
 			messages = map(dc_util.deserialise_message, response.messages) 
+			metas = map(dc_util.string_pair_list_to_dictionary, response.metas)
 
 		if single:
 			if len(messages) > 0:
-				return messages[0]
-			else:
-				return None
+				return [messages[0], metas[0]]
+			else:				
+				return [None, None]
 		else:
-			return messages
+			return [[message, meta] for message in messages for meta in metas]

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -237,3 +237,13 @@ def deserialise_message(serialised_message):
     # deserialize data into object
     message.deserialize(serialised_message.msg)
     return message
+
+
+"""
+Covert a StringPairList into a dictionary
+"""
+def string_pair_list_to_dictionary(spl):
+    d = dict()
+    for pair in spl.pairs:
+        d[pair.first] = pair.second
+    return d

--- a/ros_datacentre_msgs/CMakeLists.txt
+++ b/ros_datacentre_msgs/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation)
 add_message_files(
   FILES
   StringPair.msg
+  StringPairList.msg
   SerialisedMessage.msg
 )
 

--- a/ros_datacentre_msgs/msg/StringPairList.msg
+++ b/ros_datacentre_msgs/msg/StringPairList.msg
@@ -1,0 +1,1 @@
+StringPair[] pairs

--- a/ros_datacentre_msgs/srv/MongoQueryMsg.srv
+++ b/ros_datacentre_msgs/srv/MongoQueryMsg.srv
@@ -16,3 +16,4 @@ StringPair[] meta_query
 ---
 # messages which match the query
 SerialisedMessage[] messages
+StringPairList[] metas


### PR DESCRIPTION
This is only in the python client for now, but is simple to add to C++. This could be inefficient, so in the future potentially add non-meta options.
