### PR TITLE
Changes for strands_executive

### DIFF
--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -9,7 +9,7 @@ import rospy
 import ros_datacentre_msgs.srv as dc_srv
 import ros_datacentre.util as dc_util
 import pymongo
-import json
+from bson import json_util
 from ros_datacentre_msgs.msg import  StringPair, StringPairList
 
 
@@ -118,7 +118,7 @@ class MessageStore(object):
             message = dc_util.dictionary_to_message(entry, cls)            
             # the serialise this object in order to be sent in a generic form
             serialised_messages = serialised_messages + (dc_util.serialise_message(message), )            
-            metas = metas + (StringPairList([StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(entry["_meta"]))]), )
+            metas = metas + (StringPairList([StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(entry["_meta"]))]), )
 
         return [serialised_messages, metas]
         

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -118,6 +118,9 @@ class MessageStore(object):
             message = dc_util.dictionary_to_message(entry, cls)            
             # the serialise this object in order to be sent in a generic form
             serialised_messages = serialised_messages + (dc_util.serialise_message(message), )            
+            # add ObjectID into meta as it might be useful later
+            entry["_meta"]["_id"] = entry["_id"]
+            # serialise meta
             metas = metas + (StringPairList([StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(entry["_meta"]))]), )
 
         return [serialised_messages, metas]

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -64,7 +64,7 @@ class MessageStore(object):
 
         # TODO start using some string constants!
 
-        rospy.loginfo("update spec document: %s", obj_query) 
+        rospy.logdebug("update spec document: %s", obj_query) 
 
         # deserialize data into object
         obj = dc_util.deserialise_message(req.message)        
@@ -100,12 +100,12 @@ class MessageStore(object):
 
         # TODO start using some string constants!
 
-        rospy.loginfo("query document: %s", obj_query) 
+        rospy.logdebug("query document: %s", obj_query) 
         
         # this is a list of entries in dict format including meta
         entries =  dc_util.query_message(collection, obj_query, req.single)
 
-        # rospy.loginfo("entries: %s", entries) 
+        # rospy.logdebug("entries: %s", entries) 
 
         serialised_messages = ()
         metas = ()

--- a/ros_datacentre/scripts/mongodb_server.py
+++ b/ros_datacentre/scripts/mongodb_server.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import roslib; roslib.load_manifest('ros_datacentre')
 import rospy
 import subprocess
 import sys

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -2,8 +2,10 @@ import rospy
 import ros_datacentre_msgs.srv as dc_srv
 import ros_datacentre.util as dc_util
 from ros_datacentre_msgs.msg import StringPair, StringPairList, SerialisedMessage
-import json
+from bson import json_util
+from bson.objectid import ObjectId
 import copy
+
 
 class MessageStoreProxy:
 	def __init__(self, service_prefix='/message_store', database='message_store', collection='message_store'):
@@ -12,9 +14,11 @@ class MessageStoreProxy:
 		insert_service = service_prefix + '/insert'
 		update_service = service_prefix + '/update'
 		query_ids_service = service_prefix + '/query_messages'
+		rospy.logdebug("Waiting for services...")
 		rospy.wait_for_service(insert_service)
 		rospy.wait_for_service(update_service)
 		rospy.wait_for_service(query_ids_service)
+		rospy.logdebug("Done")
 		self.insert_srv = rospy.ServiceProxy(insert_service, dc_srv.MongoInsertMsg)
 		self.update_srv = rospy.ServiceProxy(update_service, dc_srv.MongoUpdateMsg)
 		self.query_id_srv = rospy.ServiceProxy(query_ids_service, dc_srv.MongoQueryMsg)
@@ -24,14 +28,17 @@ class MessageStoreProxy:
 		# create a copy as we're modifying it
 		meta_copy = copy.copy(meta)
 		meta_copy["name"] = name
-		self.insert(message, meta_copy)
+		return self.insert(message, meta_copy)
 	
 
 	def insert(self, message, meta = {}):
 		# assume meta is a dict, convert k/v to tuple pairs 
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
 		serialised_msg = dc_util.serialise_message(message)
-		self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple))
+		return self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple))
+
+	def query_id(self, id, type):
+		return self.query(type, {'_id': ObjectId(id)})
 
 	def query_named(self, name, type, single = True, meta = {}):
 		# create a copy as we're modifying it
@@ -50,10 +57,10 @@ class MessageStoreProxy:
 		return self.update(message, meta_copy, {}, meta_query, upsert)		
 
 	def update(self, message, meta = {}, message_query = {}, meta_query = {},  upsert = False):
-		# serialise the json queries to strings using json.dumps
-		message_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(message_query)),)
-		meta_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta_query)),)
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta)),)
+		# serialise the json queries to strings using json_util.dumps
+		message_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(message_query)),)
+		meta_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta_query)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
 		self.update_srv(self.database, self.collection, upsert, StringPairList(message_query_tuple), StringPairList(meta_query_tuple), dc_util.serialise_message(message), StringPairList(meta_tuple))		
 
 
@@ -63,9 +70,9 @@ class MessageStoreProxy:
 	def query(self, type, message_query = {}, meta_query = {}, single = False):
 		# assume meta is a dict, convert k/v to tuple pairs for ROS msg type
 
-		# serialise the json queries to strings using json.dumps
-		message_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(message_query)),)
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta_query)),)
+		# serialise the json queries to strings using json_util.dumps
+		message_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(message_query)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta_query)),)
 
 		# a tuple of SerialisedMessages
 		response = self.query_id_srv(self.database, self.collection, type, single, StringPairList(message_tuple), StringPairList(meta_tuple))		

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -61,7 +61,7 @@ class MessageStoreProxy:
 		message_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(message_query)),)
 		meta_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta_query)),)
 		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
-		self.update_srv(self.database, self.collection, upsert, StringPairList(message_query_tuple), StringPairList(meta_query_tuple), dc_util.serialise_message(message), StringPairList(meta_tuple))		
+		return self.update_srv(self.database, self.collection, upsert, StringPairList(message_query_tuple), StringPairList(meta_query_tuple), dc_util.serialise_message(message), StringPairList(meta_tuple))		
 
 
 	"""

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -35,7 +35,7 @@ class MessageStoreProxy:
 		# assume meta is a dict, convert k/v to tuple pairs 
 		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
 		serialised_msg = dc_util.serialise_message(message)
-		return self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple))
+		return self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple)).id
 
 	def query_id(self, id, type):
 		return self.query(type, {'_id': ObjectId(id)}, {}, True)

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -38,7 +38,7 @@ class MessageStoreProxy:
 		return self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple))
 
 	def query_id(self, id, type):
-		return self.query(type, {'_id': ObjectId(id)})
+		return self.query(type, {'_id': ObjectId(id)}, {}, True)
 
 	def query_named(self, name, type, single = True, meta = {}):
 		# create a copy as we're modifying it

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -2,7 +2,7 @@ import rospy
 import genpy
 from std_srvs.srv import Empty
 import yaml
-import json
+from bson import json_util
 import copy
 import StringIO
 from ros_datacentre_msgs.msg import SerialisedMessage
@@ -299,7 +299,7 @@ Creates a dictionary from a StringPairList which could contain JSON as a string
 def string_pair_list_to_dictionary(spl):
     if len(spl.pairs) > 0 and spl.pairs[0].first == MongoQueryMsgRequest.JSON_QUERY:
         # print "looks like %s", spl.pairs[0].second
-        return json.loads(spl.pairs[0].second)
+        return json_util.loads(spl.pairs[0].second)
     # else use the string pairs
     else:
         return string_pair_list_to_dictionary_no_json(spl.pairs)


### PR DESCRIPTION
- Added ability to query message store via ObjectID
- Switched to using bson dumps/loads to support additional encoding into strings for serialisation (to enable above)
