### PR TITLE
Adding an initial rostest for the message store proxy.

### DIFF
--- a/ros_datacentre/CMakeLists.txt
+++ b/ros_datacentre/CMakeLists.txt
@@ -125,6 +125,10 @@ install(DIRECTORY scripts/
 ## Testing ##
 #############
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest)
+endif()
+
 ## Add gtest based cpp test target and link libraries
 # catkin_add_gtest(${PROJECT_NAME}-test test/test_ros_datacentre.cpp)
 # if(TARGET ${PROJECT_NAME}-test)
@@ -132,4 +136,9 @@ install(DIRECTORY scripts/
 # endif()
 
 ## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+# catkin_add_nosetests(unittests/test_messagestore.py)
+
+
+if (CATKIN_ENABLE_TESTING)
+  add_rostest(tests/messagestore.test)
+endif()

--- a/ros_datacentre/package.xml
+++ b/ros_datacentre/package.xml
@@ -18,14 +18,14 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>ros_datacentre_msgs</build_depend>
+  <build_depend>rostest</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>python-pymongo</run_depend>
   <run_depend>ros_datacentre_msgs</run_depend>
-
-
+  
   <export>
 
   </export>

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -13,15 +13,18 @@ class MessageStoreProxy:
 		self.collection = collection
 		insert_service = service_prefix + '/insert'
 		update_service = service_prefix + '/update'
+		delete_service = service_prefix + '/delete'
 		query_ids_service = service_prefix + '/query_messages'
 		rospy.logdebug("Waiting for services...")
 		rospy.wait_for_service(insert_service)
 		rospy.wait_for_service(update_service)
 		rospy.wait_for_service(query_ids_service)
+		rospy.wait_for_service(delete_service)
 		rospy.logdebug("Done")
 		self.insert_srv = rospy.ServiceProxy(insert_service, dc_srv.MongoInsertMsg)
 		self.update_srv = rospy.ServiceProxy(update_service, dc_srv.MongoUpdateMsg)
 		self.query_id_srv = rospy.ServiceProxy(query_ids_service, dc_srv.MongoQueryMsg)
+		self.delete_srv = rospy.ServiceProxy(delete_service, dc_srv.MongoDeleteMsg)
 
 
 	def insert_named(self, name, message, meta = {}):
@@ -39,6 +42,15 @@ class MessageStoreProxy:
 
 	def query_id(self, id, type):
 		return self.query(type, {'_id': ObjectId(id)}, {}, True)
+	
+	def delete(self, message_id):
+		"""
+		Delete the message with the given ID.
+		
+		:Parameters:
+			message_id : string
+		"""
+		return self.delete_srv(self.database, self.collection, message_id)
 
 	def query_named(self, name, type, single = True, meta = {}):
 		# create a copy as we're modifying it

--- a/ros_datacentre/tests/messagestore.test
+++ b/ros_datacentre/tests/messagestore.test
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="db_path" default="/opt/strands/ros_datacentre"/>
+  <arg name="port" default="52346" />
+
+  <param name="datacentre_port" value="$(arg port)" />
+  <param name="datacentre_host" value="$(optenv HOSTNAME localhost)" />
+  
+  <node name="mongo_server" pkg="ros_datacentre" type="mongodb_server.py" output="screen">
+    <param name="database_path" value="$(arg db_path)"/>
+  </node>
+
+  <node name="message_store" pkg="ros_datacentre" type="message_store_node.py" output="screen"/>
+
+  <!-- rosout and diagnostic topic logger -->
+  <!-- <node name="diagnostics_logger" pkg="strands_diagnostics" type="logger" output="screen"/> -->
+  
+  <test test-name="test_messagestore" pkg="ros_datacentre" type="test_messagestore.py" />
+
+</launch>

--- a/ros_datacentre/tests/test_messagestore.py
+++ b/ros_datacentre/tests/test_messagestore.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import sys
+import unittest
+import random
+from ros_datacentre.message_store import MessageStoreProxy
+from geometry_msgs.msg import Pose, Point, Quaternion
+
+class TestMessageStoreProxy(unittest.TestCase):
+
+    def test_add_message(self):
+        msg_store = MessageStoreProxy()
+        POSE_NAME = "test_pose_6"
+        p = Pose(Point(0, 1, 2), Quaternion(0, 0, 0, 1))
+      
+        # insert a pose object with a name
+        msg_store.insert_named(POSE_NAME, p)
+ 
+        # get it back with a name
+        stored = msg_store.query_named(POSE_NAME, Pose._type)[0]
+
+        self.assertIsInstance(stored, Pose)
+        self.assertEqual(stored.position.x, p.position.x)
+        self.assertEqual(stored.position.y, p.position.y)
+        self.assertEqual(stored.position.z, p.position.z)
+
+        self.assertEqual(stored.orientation.x, p.orientation.x)
+        self.assertEqual(stored.orientation.y, p.orientation.y)
+        self.assertEqual(stored.orientation.z, p.orientation.z)
+        self.assertEqual(stored.orientation.w, p.orientation.w)
+
+        p.position.x = 666
+
+        msg_store.update_named(POSE_NAME, p)
+
+        # get it back with a name
+        updated = msg_store.query_named(POSE_NAME, Pose._type)[0]
+
+        self.assertEqual(updated.position.x, p.position.x)
+
+        # # try to get it back with an incorrect name
+        wrong_name = "thid name does not exist in the datacentre"
+        none_item = msg_store.query_named(wrong_name, Pose._type)[0]
+        self.assertIsNone(none_item)
+
+        # # get all non-existant typed objects, so get an empty list back
+        none_query = msg_store.query( "not my type")
+        self.assertEqual(len(none_query), 0)
+        
+        # URGENT TODO: must remove the item or unittest only really valid once
+
+        
+
+    
+    
+if __name__ == '__main__':
+    import rostest
+    PKG = 'ros_datacentre'
+    rostest.rosrun(PKG, 'test_message_store_proxy', TestMessageStoreProxy)
+    
+ 

--- a/ros_datacentre/tests/test_messagestore.py
+++ b/ros_datacentre/tests/test_messagestore.py
@@ -10,14 +10,14 @@ class TestMessageStoreProxy(unittest.TestCase):
 
     def test_add_message(self):
         msg_store = MessageStoreProxy()
-        POSE_NAME = "test_pose_6"
+        POSE_NAME = "__test__pose__"
         p = Pose(Point(0, 1, 2), Quaternion(0, 0, 0, 1))
       
         # insert a pose object with a name
         msg_store.insert_named(POSE_NAME, p)
  
         # get it back with a name
-        stored = msg_store.query_named(POSE_NAME, Pose._type)[0]
+        stored, meta = msg_store.query_named(POSE_NAME, Pose._type)
 
         self.assertIsInstance(stored, Pose)
         self.assertEqual(stored.position.x, p.position.x)
@@ -47,9 +47,11 @@ class TestMessageStoreProxy(unittest.TestCase):
         none_query = msg_store.query( "not my type")
         self.assertEqual(len(none_query), 0)
         
-        # URGENT TODO: must remove the item or unittest only really valid once
-
-        
+        # must remove the item or unittest only really valid once
+        print meta["_id"]
+        print str(meta["_id"])
+        deleted = msg_store.delete(str(meta["_id"]))
+        self.assertTrue(deleted)
 
     
     

--- a/ros_datacentre_msgs/CMakeLists.txt
+++ b/ros_datacentre_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ add_service_files(
   MongoInsertMsg.srv
   MongoUpdateMsg.srv
   MongoQueryMsg.srv
+  MongoDeleteMsg.srv
 )
 
 generate_messages()

--- a/ros_datacentre_msgs/srv/MongoDeleteMsg.srv
+++ b/ros_datacentre_msgs/srv/MongoDeleteMsg.srv
@@ -1,0 +1,5 @@
+string database
+string collection
+string document_id 
+---
+bool success


### PR DESCRIPTION
This adds a basic testing on the message store. It can be started either with `catkin_make run_tests_ros_datacentre`, or `rostest ros_datacentre`.

However, it will only succeed once as it adds a test message that it then should also remove. See issue #33. So it can't be added to jenkins just yet...
