### PR TITLE
Added replication for message store

### DIFF
--- a/ros_datacentre/CMakeLists.txt
+++ b/ros_datacentre/CMakeLists.txt
@@ -37,6 +37,7 @@ add_service_files(
   MongoInsert.srv
 )
 
+
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
   DEPENDENCIES

--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -132,3 +132,12 @@ ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]
 ```
 
 Inserts and updates are performed acorss the main and replicant datacentres, queries are performed on the main first, and if nothing found, the replicants are tried.
+
+You can launch additional datacentres as follows, e.g.
+
+```bash
+rosrun ros_datacentre mongodb_server.py _master:=false _database_path:=/opt/strands/strands_datacentre_62344 _host:=localhost _port:=62344
+rosrun ros_datacentre mongodb_server.py _master:=false _database_path:=/opt/strands/strands_datacentre_62333 _host:=localhost _port:=62333
+```
+
+You can test if this works by adding some things to the message store, deleting them from the master using RoboMongo (not the message store as the deletes are replicated), then running queries.

--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -121,3 +121,14 @@ HOSTNAME=yourhost roslaunch ros_datacentre datacentre.launch db_path:=/path/to/d
 
 The HOSTNAME env variable is required; db_path will default to /opt/strands/ros_datacentre and db_port will default to 62345. 
 
+
+Replication
+-----------
+
+Replication of the message store parts of the datacentre is done manually to allow different content to appear on different hosts. A list of hosts and ports where replications should be made can be set via the `ros_datacentre_extras` parameter:
+
+```yaml
+ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]
+```
+
+Inserts and updates are performed acorss the main and replicant datacentres, queries are performed on the main first, and if nothing found, the replicants are tried.

--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -144,8 +144,22 @@ rosrun ros_datacentre mongodb_server.py _master:=false _database_path:=/opt/stra
 
 You can test if this works by adding some things to the message store, deleting them from the master using RoboMongo (not the message store as the deletes are replicated), then running queries.
 
-Scheduled Replication
----------------------
+Action Server for Replication
+-----------------------------
 
+The `MoveEntries` action and the corresponding action server:
 
+```bash
+rosrun ros_datacentre replicator_node.py 
+```
+
+(which is included in `datacentre.launch`)
+
+allows you to bulk copy or move entries from message store collections to the mongod instances defined under `ros_datacentre_extras`. The client accepts a list of collection names and uses the `meta["inserted_at"]` field of the message store entries to replicate or move all entries that were inserted before a particular time. There is an example client that does this for a list of collections specified on the command line. This *moves* entries inserted 24 hours ago or earlier.
+
+```bash
+rosrun ros_datacentre replicator_client.py message_store robblog scheduling_problems
+```
+
+**NOTE THAT this all makes `update` operations a bit uncertain, so please do not use this type of replication on collections you plan to use update on.**
 

--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -123,15 +123,17 @@ The HOSTNAME env variable is required; db_path will default to /opt/strands/ros_
 
 
 Replication
------------
+===========
 
-Replication of the message store parts of the datacentre is done manually to allow different content to appear on different hosts. A list of hosts and ports where replications should be made can be set via the `ros_datacentre_extras` parameter:
+If the constructor arcgument to the message store node `replicate_on_write` is set to true, replication of the message store parts of the datacentre is done manually to allow different content to appear on different hosts. A list of hosts and ports where replications should be made can be set via the `ros_datacentre_extras` parameter:
 
 ```yaml
 ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]
 ```
 
-Inserts and updates are performed acorss the main and replicant datacentres, queries are performed on the main first, and if nothing found, the replicants are tried.
+Inserts and updates are performed acorss the main and replicant datacentres.
+
+If `ros_datacentre_extras` is set (regardless of `replicate_on_write`), queries are performed on the main first, and if nothing found, the replicants are tried.
 
 You can launch additional datacentres as follows, e.g.
 
@@ -141,3 +143,9 @@ rosrun ros_datacentre mongodb_server.py _master:=false _database_path:=/opt/stra
 ```
 
 You can test if this works by adding some things to the message store, deleting them from the master using RoboMongo (not the message store as the deletes are replicated), then running queries.
+
+Scheduled Replication
+---------------------
+
+
+

--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -155,7 +155,7 @@ rosrun ros_datacentre replicator_node.py
 
 (which is included in `datacentre.launch`)
 
-allows you to bulk copy or move entries from message store collections to the mongod instances defined under `ros_datacentre_extras`. The client accepts a list of collection names and uses the `meta["inserted_at"]` field of the message store entries to replicate or move all entries that were inserted before a particular time. There is an example client that does this for a list of collections specified on the command line. This *moves* entries inserted 24 hours ago or earlier.
+allows you to bulk copy or move entries from message store collections to the mongod instances defined under `ros_datacentre_extras`. The client accepts a list of collection names and uses the `meta["inserted_at"]` field of the message store entries to replicate or move all entries that were inserted before a particular time. If no time is provided then the default is 24 hours ago. There is an example client that does this for a list of collections specified on the command line. This *moves* entries inserted 24 hours ago or earlier.
 
 ```bash
 rosrun ros_datacentre replicator_client.py message_store robblog scheduling_problems

--- a/ros_datacentre/backup_config.yaml
+++ b/ros_datacentre/backup_config.yaml
@@ -1,1 +1,2 @@
-ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]
+# ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]
+ros_datacentre_extras: [["localhost", 62333]]

--- a/ros_datacentre/backup_config.yaml
+++ b/ros_datacentre/backup_config.yaml
@@ -1,0 +1,1 @@
+ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]

--- a/ros_datacentre/example_replication_config.yaml
+++ b/ros_datacentre/example_replication_config.yaml
@@ -1,0 +1,1 @@
+ros_datacentre_extras: [["localhost", 62344], ["localhost", 62333]]

--- a/ros_datacentre/launch/datacentre.launch
+++ b/ros_datacentre/launch/datacentre.launch
@@ -13,6 +13,8 @@
 
   <node name="message_store" pkg="ros_datacentre" type="message_store_node.py" output="screen"/>
 
+  <node name="replicator_node" pkg="ros_datacentre" type="replicator_node.py" output="screen"/>
+
   <!-- rosout and diagnostic topic logger -->
   <!-- <node name="diagnostics_logger" pkg="strands_diagnostics" type="logger" output="screen"/> -->
 </launch>

--- a/ros_datacentre/package.xml
+++ b/ros_datacentre/package.xml
@@ -19,7 +19,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>ros_datacentre_msgs</build_depend>
   <build_depend>rostest</build_depend>
-
+  
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>

--- a/ros_datacentre/scripts/example_message_store_client.py
+++ b/ros_datacentre/scripts/example_message_store_client.py
@@ -51,22 +51,22 @@ if __name__ == '__main__':
         # some other things you can do...
 
         # get it back with a name
-        # print msg_store.query_named("my favourite pose", Pose._type)
+        print msg_store.query_named("my favourite pose", Pose._type)
 
 
-        # # try to get it back with an incorrect name, so get None instead
-        # print msg_store.query_named("my favourite position", Pose._type)
+        # try to get it back with an incorrect name, so get None instead
+        print msg_store.query_named("my favourite position", Pose._type)
 
-        # # get all poses  
-        # print msg_store.query(Pose._type)
-        # # get all non-existant typed objects, so get an empty list back
-        # print msg_store.query( "not my type")
+        # get all poses  
+        print msg_store.query(Pose._type)
+        # get all non-existant typed objects, so get an empty list back
+        print msg_store.query( "not my type")
         
-        # # get all poses where the y position is 1
-        # print msg_store.query(Pose._type, {"position.y": 1})
+        # get all poses where the y position is 1
+        print msg_store.query(Pose._type, {"position.y": 1})
 
-        # # get all poses where the y position greater than 0
-        # print msg_store.query(Pose._type, {"position.y": {"$gt": 0}})
+        # get all poses where the y position greater than 0
+        print msg_store.query(Pose._type, {"position.y": {"$gt": 0}})
 
         
     except rospy.ServiceException, e:

--- a/ros_datacentre/scripts/example_message_store_client.py
+++ b/ros_datacentre/scripts/example_message_store_client.py
@@ -26,6 +26,7 @@ if __name__ == '__main__':
         # you don't need a name (note that this p_id is different than one above)
         p_id = msg_store.insert(p)
 
+        p_id = msg_store.insert(['test1', 'test2'])         
 
         # get it back with a name
         print msg_store.query_named("my favourite pose", Pose._type)

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -25,6 +25,18 @@ class MessageStore(object):
         self._mongo_client=pymongo.MongoClient(rospy.get_param("datacentre_host"),
                                                rospy.get_param("datacentre_port") )
 
+
+        extras = rospy.get_param('ros_datacentre_extras', [])
+        self.extra_clients = []
+        for extra in extras:
+            try:
+                self.extra_clients.append(pymongo.MongoClient(extra[0], extra[1]))
+            except pymongo.errors.ConnectionFailure, e:
+                rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
+            
+        rospy.loginfo('Replicating content to a futher %s datacentres',len(self.extra_clients))
+
+
         # advertise ros services
         for attr in dir(self):
             if attr.endswith("_ros_srv"):

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -23,9 +23,10 @@ if __name__ == '__main__':
 
     print collections
 
-    # a_while_ago = rospy.get_rostime() - rospy.Duration(60 * 5)
-    a_while_ago = rospy.get_rostime()
-    goal = MoveEntriesGoal(collections=collections, move_before=a_while_ago)
+    a_while_ago = rospy.get_rostime() - rospy.Duration(60 * 30)
+    # a_while_ago = rospy.get_rostime()
+    goal = MoveEntriesGoal(collections=collections, move_before=a_while_ago, delete_after_move=True)
+
 
     client.send_goal(goal, feedback_cb=feedback)
     client.wait_for_result()

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Provides a service to store ROS message objects in a mongodb database in JSON.
+"""
+
+import rospy
+import actionlib
+from ros_datacentre_msgs.msg import  MoveEntriesAction, MoveEntriesGoal
+import sys
+
+def feedback(feedback):
+    print feedback
+
+if __name__ == '__main__':
+    rospy.init_node("mongodb_replicator_client")
+
+    client = actionlib.SimpleActionClient('move_datacentre_entries', MoveEntriesAction)
+    client.wait_for_server()
+
+    collections = sys.argv[1:]
+
+    print collections
+
+    goal = MoveEntriesGoal(collections=collections)
+
+    client.send_goal(goal, feedback_cb=feedback)
+    client.wait_for_result()

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -7,7 +7,7 @@ Provides a service to store ROS message objects in a mongodb database in JSON.
 
 import rospy
 import actionlib
-from ros_datacentre_msgs.msg import  MoveEntriesAction, MoveEntriesGoal
+from ros_datacentre_msgs.msg import  MoveEntriesAction, MoveEntriesGoal, StringList
 import sys
 
 def feedback(feedback):
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     # but this is the default anyway
     twenty_four_hrs_ago = rospy.Duration(60 * 60 * 24)
-    goal = MoveEntriesGoal(collections=collections, move_before=twenty_four_hrs_ago, delete_after_move=True)
+    goal = MoveEntriesGoal(collections=StringList(collections), move_before=twenty_four_hrs_ago, delete_after_move=True)
 
 
     client.send_goal(goal, feedback_cb=feedback)

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -23,7 +23,8 @@ if __name__ == '__main__':
 
     print collections
 
-    twenty_four_hrs_ago = rospy.get_rostime() - rospy.Duration(60 * 60 * 24)
+    # but this is the default anyway
+    twenty_four_hrs_ago = rospy.Duration(60 * 60 * 24)
     goal = MoveEntriesGoal(collections=collections, move_before=twenty_four_hrs_ago, delete_after_move=True)
 
 

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -23,9 +23,8 @@ if __name__ == '__main__':
 
     print collections
 
-    a_while_ago = rospy.get_rostime() - rospy.Duration(60 * 30)
-    # a_while_ago = rospy.get_rostime()
-    goal = MoveEntriesGoal(collections=collections, move_before=a_while_ago, delete_after_move=True)
+    twenty_four_hrs_ago = rospy.get_rostime() - rospy.Duration(60 * 60 * 24)
+    goal = MoveEntriesGoal(collections=collections, move_before=twenty_four_hrs_ago, delete_after_move=True)
 
 
     client.send_goal(goal, feedback_cb=feedback)

--- a/ros_datacentre/scripts/replicator_client.py
+++ b/ros_datacentre/scripts/replicator_client.py
@@ -23,7 +23,9 @@ if __name__ == '__main__':
 
     print collections
 
-    goal = MoveEntriesGoal(collections=collections)
+    # a_while_ago = rospy.get_rostime() - rospy.Duration(60 * 5)
+    a_while_ago = rospy.get_rostime()
+    goal = MoveEntriesGoal(collections=collections, move_before=a_while_ago)
 
     client.send_goal(goal, feedback_cb=feedback)
     client.wait_for_result()

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Provides a service to store ROS message objects in a mongodb database in JSON.
+"""
+
+import rospy
+import actionlib
+import pymongo
+import os
+import shutil
+import subprocess
+from ros_datacentre_msgs.msg import  MoveEntriesAction, MoveEntriesFeedback
+from datetime import *
+
+class Replicator(object):
+    def __init__(self):
+
+        # this is just a test, connections are remade every call for long-running processes
+        master, extras = self.make_connections()
+        if master is None:
+            raise Exception("No master datacentre found using datacentre_host and datacentre_port")
+
+        self.server = actionlib.SimpleActionServer('move_datacentre_entries', MoveEntriesAction, self.move_entries, False)
+        self.server.start()
+        self.dump_path = '/tmp/mongodb_replicator'
+
+        self.make_path()
+        self.remove_path()
+
+
+    def make_path(self):        
+        if not os.path.isdir(self.dump_path):
+            os.makedirs(self.dump_path) 
+        elif not os.access(self.dump_path, os.W_OK):
+            raise Exception('Cannot write to dump path: %s' % self.dump_path)
+        
+    def remove_path(self):
+        shutil.rmtree(self.dump_path)
+
+    def make_connections(self):
+        datacentre_host = rospy.get_param("datacentre_host")
+        datacentre_port = rospy.get_param("datacentre_port") 
+        master = None
+        try:
+            master = pymongo.MongoClient(datacentre_host, datacentre_port)
+        except pymongo.errors.ConnectionFailure, e:
+            rospy.logwarn('Could not connect to master datacentre at %s:%s' % (datacentre_host, datacentre_port))
+            return None, None
+
+
+        extras = rospy.get_param('ros_datacentre_extras', [])
+        extra_clients = []
+        for extra in extras:
+            try:
+                extra_clients.append(pymongo.MongoClient(extra[0], extra[1]))
+            except pymongo.errors.ConnectionFailure, e:
+                rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
+
+
+        rospy.loginfo('Replicating content from %s:%s to a futher %s datacentres', datacentre_host, datacentre_port, len(extra_clients))
+
+        return master, extra_clients
+
+    def move_entries(self, goal):
+
+        # create place to put temp stuf
+        self.make_path()
+        
+        # don't use the connections, just sanity check their existence
+        master, extras = self.make_connections()
+        
+
+        completed = []
+        feedback = MoveEntriesFeedback(completed=completed)
+
+        for collection in goal.collections:                    
+            self.do_dump(collection, master)
+
+        self.do_restore(extras)
+
+
+
+        # clean up
+        # self.remove_path()
+
+        self.server.set_succeeded()    
+
+    def do_restore(self, extras, db='message_store'):       
+        # restore collection to extras
+        for extra in extras:            
+            rest_args = ['mongorestore',  '--host',  extra.host, '--port',  str(extra.port), self.dump_path]
+            subprocess.call(rest_args)    
+
+
+    def do_dump(self, collection, master, db='message_store'):       
+        # dump collection
+        args = ['mongodump',  '--host',  master.host, '--port',  str(master.port), '--db', db, '--collection', collection, '-o', self.dump_path]
+        subprocess.call(args)
+
+
+
+if __name__ == '__main__':
+    rospy.init_node("mongodb_replicator")
+
+    store = Replicator()
+    
+    rospy.spin()

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -81,13 +81,13 @@ class Replicator(object):
         
         less_time_time = rospy.get_rostime() - goal.move_before
 
-        for collection in goal.collections:                    
+        for collection in goal.collections.data:                    
             self.do_dump(collection, master, less_time_time)
 
         self.do_restore(extras)
 
         if goal.delete_after_move:  
-            for collection in goal.collections:                    
+            for collection in goal.collections.data:                    
                 self.do_delete(collection, master, less_time_time)
 
         # clean up

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -78,8 +78,10 @@ class Replicator(object):
 
         completed = []
         feedback = MoveEntriesFeedback(completed=completed)
+        
+        twenty_four_hrs_ago = rospy.get_rostime() - rospy.Duration(60 * 60 * 24)
+        less_time_time = twenty_four_hrs_ago
 
-        less_time_time = rospy.get_rostime()
         if goal.move_before.secs > 0:
             less_time_time = goal.move_before
 

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -79,11 +79,7 @@ class Replicator(object):
         completed = []
         feedback = MoveEntriesFeedback(completed=completed)
         
-        twenty_four_hrs_ago = rospy.get_rostime() - rospy.Duration(60 * 60 * 24)
-        less_time_time = twenty_four_hrs_ago
-
-        if goal.move_before.secs > 0:
-            less_time_time = goal.move_before
+        less_time_time = rospy.get_rostime() - goal.move_before
 
         for collection in goal.collections:                    
             self.do_dump(collection, master, less_time_time)

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -71,6 +71,10 @@ class Replicator(object):
         # don't use the connections, just sanity check their existence
         master, extras = self.make_connections()
         
+        if len(extras) == 0:
+            rospy.logwarn('No datacentres to move to, not performing move')
+            self.server.set_aborted()    
+            return 
 
         completed = []
         feedback = MoveEntriesFeedback(completed=completed)
@@ -84,10 +88,12 @@ class Replicator(object):
 
         self.do_restore(extras)
 
-
+        if goal.delete_after_move:  
+            for collection in goal.collections:                    
+                self.do_delete(collection, master, less_time_time)
 
         # clean up
-        # self.remove_path()
+        self.remove_path()
 
         self.server.set_succeeded()    
 
@@ -98,20 +104,28 @@ class Replicator(object):
             subprocess.call(rest_args)    
 
 
+    def do_delete(self, collection, master, less_time_time=None, db='message_store'):       
+        coll = master[db][collection]
+        spec = None
+        if less_time_time is not None:
+            spec = {"_meta.inserted_at": { "$lt": datetime.utcfromtimestamp(less_time_time.to_sec())}}
+        coll.remove(spec)
+
+
+
     def do_dump(self, collection, master, less_time_time=None, db='message_store'):       
         # dump collection
 
-        print 'dumping ', collection
+        # print 'dumping ', collection
 
         args = ['mongodump',  '--host',  master.host, '--port',  str(master.port), '--db', db, '--collection', collection, '-o', self.dump_path]
 
         if less_time_time is not None:
             # match only objects with an insterted data less than this
-            print 'addoimg'
             args.append('--query')
             args.append('{ \"_meta.inserted_at\": { $lt: new Date(%s)}}' % (less_time_time.secs * 1000))
 
-        print args
+        # print args
 
         subprocess.call(args)
 

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -135,10 +135,13 @@ def sanitize_value(attr, v, type):
     elif isinstance(v, genpy.rostime.Duration):
          return msg_to_document(v)
     elif isinstance(v, list):
-        if hasattr(v[0], '_type'):
-            return [sanitize_value(None, t, t._type) for t in v]
-        else: 
-            return [sanitize_value(None, t, None) for t in v]
+        result = []
+        for t in v:            
+            if hasattr(t, '_type'):
+                result.append(sanitize_value(None, t, t._type))
+            else: 
+                result.append(sanitize_value(None, t, None))
+        return result
     else:
         return v
 

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -143,12 +143,20 @@ def sanitize_value(attr, v, type):
         return v
 
 
+
+
 """
-Store a ROS message into the DB
+Update ROS message into the DB
 """    
-def store_message(collection, msg, meta):
+def store_message(collection, msg, meta, oid=None):
     doc=msg_to_document(msg)
     doc["_meta"]=meta
+    #  also store type information
+    doc["_meta"]["stored_class"] = msg.__module__ + "." + msg.__class__.__name__
+    doc["_meta"]["stored_type"] = msg._type
+    if oid != None:
+        doc["_id"] = oid
+
     return collection.insert(doc)
 
 # """
@@ -221,17 +229,7 @@ def query_message(collection, query_doc, find_one):
         return [ result for result in collection.find(query_doc) ]
 
 
-"""
-Update ROS message into the DB
-"""    
-def store_message(collection, msg, meta):
-    doc=msg_to_document(msg)
-    doc["_meta"]=meta
-    #  also store type information
-    doc["_meta"]["stored_class"] = msg.__module__ + "." + msg.__class__.__name__
-    doc["_meta"]["stored_type"] = msg._type
-       
-    return collection.insert(doc)
+
 
 
 """

--- a/ros_datacentre_msgs/CMakeLists.txt
+++ b/ros_datacentre_msgs/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation actionlib actionlib_m
 
 add_message_files(
   FILES
+  StringList.msg
   StringPair.msg
   StringPairList.msg
   SerialisedMessage.msg

--- a/ros_datacentre_msgs/CMakeLists.txt
+++ b/ros_datacentre_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ros_datacentre_msgs)
 
-find_package(catkin REQUIRED COMPONENTS message_generation)
+find_package(catkin REQUIRED COMPONENTS message_generation actionlib actionlib_msgs)
 
 add_message_files(
   FILES
@@ -18,7 +18,13 @@ add_service_files(
   MongoDeleteMsg.srv
 )
 
-generate_messages()
+add_action_files(
+  FILES
+  MoveEntries.action
+)
+
+
+generate_messages(DEPENDENCIES actionlib_msgs)
 
 catkin_package(
  CATKIN_DEPENDS message_generation

--- a/ros_datacentre_msgs/action/MoveEntries.action
+++ b/ros_datacentre_msgs/action/MoveEntries.action
@@ -2,6 +2,7 @@
 string[] collections
 # only entries before this are moved. if 0, all are moved
 time move_before
+bool delete_after_move
 ---
 
 ---

--- a/ros_datacentre_msgs/action/MoveEntries.action
+++ b/ros_datacentre_msgs/action/MoveEntries.action
@@ -1,5 +1,5 @@
 # the collections to move entries from
-string[] collections
+StringList collections
 # only entries before rospy.get_rostime() - move_before are moved. if 0, all are moved
 duration move_before
 bool delete_after_move

--- a/ros_datacentre_msgs/action/MoveEntries.action
+++ b/ros_datacentre_msgs/action/MoveEntries.action
@@ -1,7 +1,7 @@
 # the collections to move entries from
 string[] collections
-# only entries before this are moved. if 0, all are moved
-time move_before
+# only entries before rospy.get_rostime() - move_before are moved. if 0, all are moved
+duration move_before
 bool delete_after_move
 ---
 

--- a/ros_datacentre_msgs/action/MoveEntries.action
+++ b/ros_datacentre_msgs/action/MoveEntries.action
@@ -1,0 +1,9 @@
+# the collections to move entries from
+string[] collections
+# only entries before this are moved. if 0, all are moved
+time move_before
+---
+
+---
+# the collections which have been operated on so far
+string[] completed

--- a/ros_datacentre_msgs/msg/StringList.msg
+++ b/ros_datacentre_msgs/msg/StringList.msg
@@ -1,0 +1,1 @@
+string[] data

--- a/ros_datacentre_msgs/package.xml
+++ b/ros_datacentre_msgs/package.xml
@@ -21,4 +21,10 @@
   <run_depend>message_runtime</run_depend>
    <run_depend>message_generation</run_depend>
 
+<build_depend>actionlib_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
+
+<run_depend>actionlib_msgs</run_depend>
+  <run_depend>actionlib</run_depend>
+  
 </package>


### PR DESCRIPTION
As discussed in Lincoln, I've added the ability for the message store to write to and query multiple databases. This supports the (external) deletion of content from the "main" message store database, but allowing queries to succeed on the replicated content. A little more information at https://github.com/hawesie/ros_datacentre/tree/hydro-devel/ros_datacentre#replication
