### PR TITLE
Remove dependency on pymongo 2.3+

### DIFF
--- a/mongodb_log/package.xml
+++ b/mongodb_log/package.xml
@@ -4,41 +4,11 @@
   <version>0.0.1</version>
   <description>The mongodb_log package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <author email="tim@niemueller.de">Tim Niemueller</author>
   <maintainer email="marc@hanheide.net">Marc Hanheide</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>GPLv2</license>
-
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
   <url type="website">http://ros.org/wiki/mongodb_log</url>
 
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <author email="tim@niemueller.de">Tim Niemueller</author>
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>rospy</build_depend>
@@ -56,14 +26,8 @@
   <run_depend>tf</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>mongodb-dev</run_depend>
+  <run_depend>python-pymongo</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
   </export>
 </package>

--- a/mongodb_log/scripts/mongodb_log.py
+++ b/mongodb_log/scripts/mongodb_log.py
@@ -71,8 +71,10 @@ import roslib.message
 import rostopic
 
 
-from pymongo import Connection, SLOW_ONLY
+from pymongo import SLOW_ONLY
 from pymongo.errors import InvalidDocument, InvalidStringData
+
+MongoClient = ros_datacentre.util.import_MongoClient()
 
 BACKLOG_WARN_LIMIT = 100
 STATS_LOOPTIME     = 10
@@ -140,7 +142,7 @@ class WorkerProcess(object):
         if use_setproctitle: 
             setproctitle("mongodb_log %s" % self.topic)
 
-        self.mongoconn = Connection(self.mongodb_host, self.mongodb_port)
+        self.mongoconn = MongoClient(self.mongodb_host, self.mongodb_port)
         self.mongodb = self.mongoconn[self.mongodb_name]
         self.mongodb.set_profiling_level = SLOW_ONLY
 

--- a/mongodb_log/scripts/mongodb_log.py
+++ b/mongodb_log/scripts/mongodb_log.py
@@ -42,6 +42,7 @@ import sys
 import time
 import pprint
 import string
+import signal
 import subprocess
 from threading import Thread, Timer
 from multiprocessing import Process, Lock, Condition, Queue, Value, current_process, Event
@@ -148,7 +149,9 @@ class WorkerProcess(object):
 
         self.queue.cancel_join_thread()
 
-
+        # clear signal handlers in this child process, rospy will handle signals for us
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
         worker_node_name = WORKER_NODE_NAME % (self.nodename_prefix, self.id, self.collname)
         # print "Calling init_node with %s from process %s" % (worker_node_name, mp.current_process())
@@ -364,11 +367,6 @@ class MongoWriter(object):
             self.ros_master = rosgraph.masterapi.Master(NODE_NAME_TEMPLATE % self.nodename_prefix)
             self.update_topics(restart=False)
 
-        node_name = NODE_NAME_TEMPLATE % self.nodename_prefix
-        # print "Calling init_node with %s from process %s" % (node_name, mp.current_process())
-        
-        rospy.init_node(node_name, anonymous=True)
-
         self.start_all_topics_timer()
 
     def subscribe_topics(self, topics):
@@ -457,13 +455,13 @@ class MongoWriter(object):
     def run(self):
         looping_threshold = timedelta(0, STATS_LOOPTIME,  0)
 
-        while not rospy.is_shutdown() and not self.quit:
+        while not self.quit:
             started = datetime.now()        
 
             # the following code makes sure we run once per STATS_LOOPTIME, taking
             # varying run-times and interrupted sleeps into account
             td = datetime.now() - started
-            while not rospy.is_shutdown() and not self.quit and td < looping_threshold:
+            while not self.quit and td < looping_threshold:
                 sleeptime = STATS_LOOPTIME - (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
                 if sleeptime > 0: sleep(sleeptime)
                 td = datetime.now() - started
@@ -576,8 +574,13 @@ def main(argv):
                               no_specific=options.no_specific,
                               nodename_prefix=options.nodename_prefix)
 
+    def signal_handler(signal, frame):
+        mongowriter.shutdown()
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
     mongowriter.run()
-    mongowriter.shutdown()
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/ros_datacentre/scripts/config_manager.py
+++ b/ros_datacentre/scripts/config_manager.py
@@ -19,6 +19,7 @@ if not ros_datacentre.util.check_for_pymongo():
     sys.exit(1)
 
 import pymongo
+MongoClient = ros_datacentre.util.import_MongoClient()
 
 class MongoTransformer(pymongo.son_manipulator.SONManipulator):
     def __init__(self):
@@ -70,7 +71,7 @@ class ConfigManager(object):
         if not ros_datacentre.util.wait_for_mongo():
             sys.exit(1)
         
-        self._mongo_client = pymongo.Connection(rospy.get_param("datacentre_host","localhost"),
+        self._mongo_client = MongoClient(rospy.get_param("datacentre_host","localhost"),
                                                  int(rospy.get_param("datacentre_port")))
 
         self._database=self._mongo_client.config

--- a/ros_datacentre/scripts/config_manager.py
+++ b/ros_datacentre/scripts/config_manager.py
@@ -70,7 +70,7 @@ class ConfigManager(object):
         if not ros_datacentre.util.wait_for_mongo():
             sys.exit(1)
         
-        self._mongo_client = pymongo.MongoClient(rospy.get_param("datacentre_host","localhost"),
+        self._mongo_client = pymongo.Connection(rospy.get_param("datacentre_host","localhost"),
                                                  int(rospy.get_param("datacentre_port")))
 
         self._database=self._mongo_client.config

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -15,6 +15,8 @@ from ros_datacentre_msgs.msg import  StringPair, StringPairList
 from bson.objectid import ObjectId
 from datetime import *
 
+MongoClient = dc_util.import_MongoClient()
+
 class MessageStore(object):
     def __init__(self, replicate_on_write=False):
 
@@ -24,7 +26,7 @@ class MessageStore(object):
         if not have_dc:
             raise Exception("No Datacentre?")
 
-        self._mongo_client=pymongo.Connection(rospy.get_param("datacentre_host"),
+        self._mongo_client=MongoClient(rospy.get_param("datacentre_host"),
                                               rospy.get_param("datacentre_port") )
 
 
@@ -32,7 +34,7 @@ class MessageStore(object):
         self.extra_clients = []
         for extra in extras:
             try:
-                self.extra_clients.append(pymongo.Connection(extra[0], extra[1]))
+                self.extra_clients.append(MongoClient(extra[0], extra[1]))
             except pymongo.errors.ConnectionFailure, e:
                 rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
 

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -9,6 +9,7 @@ import rospy
 import ros_datacentre_msgs.srv as dc_srv
 import ros_datacentre.util as dc_util
 import pymongo
+import json
 from bson import json_util
 from ros_datacentre_msgs.msg import  StringPair, StringPairList
 from bson.objectid import ObjectId
@@ -205,7 +206,7 @@ class MessageStore(object):
             # add ObjectID into meta as it might be useful later
             entry["_meta"]["_id"] = entry["_id"]
             # serialise meta
-            metas = metas + (StringPairList([StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(entry["_meta"]))]), )
+            metas = metas + (StringPairList([StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(entry["_meta"], default=json_util.default))]), )
 
         return [serialised_messages, metas]
         

--- a/ros_datacentre/scripts/message_store_node.py
+++ b/ros_datacentre/scripts/message_store_node.py
@@ -23,15 +23,15 @@ class MessageStore(object):
         if not have_dc:
             raise Exception("No Datacentre?")
 
-        self._mongo_client=pymongo.MongoClient(rospy.get_param("datacentre_host"),
-                                               rospy.get_param("datacentre_port") )
+        self._mongo_client=pymongo.Connection(rospy.get_param("datacentre_host"),
+                                              rospy.get_param("datacentre_port") )
 
 
         extras = rospy.get_param('ros_datacentre_extras', [])
         self.extra_clients = []
         for extra in extras:
             try:
-                self.extra_clients.append(pymongo.MongoClient(extra[0], extra[1]))
+                self.extra_clients.append(pymongo.Connection(extra[0], extra[1]))
             except pymongo.errors.ConnectionFailure, e:
                 rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
 

--- a/ros_datacentre/scripts/mongo_bridge.py
+++ b/ros_datacentre/scripts/mongo_bridge.py
@@ -16,6 +16,8 @@ import pymongo
 import bson.json_util 
 import json
 
+MongoClient = dc_util.import_MongoClient()
+
 class MongoBridge(object):
     def __init__(self):
         rospy.init_node("mongo_bridge")
@@ -24,8 +26,8 @@ class MongoBridge(object):
         if not have_dc:
             raise Exception("No Datacentre?")
 
-        self._mongo_client=pymongo.Connection(rospy.get_param("datacentre_host"),
-                                              rospy.get_param("datacentre_port") )
+        self._mongo_client=pymongo.MongoClient(rospy.get_param("datacentre_host"),
+                                               rospy.get_param("datacentre_port") )
 
         # advertise ros services
         for attr in dir(self):

--- a/ros_datacentre/scripts/mongo_bridge.py
+++ b/ros_datacentre/scripts/mongo_bridge.py
@@ -23,8 +23,8 @@ class MongoBridge(object):
         if not have_dc:
             raise Exception("No Datacentre?")
 
-        self._mongo_client=pymongo.MongoClient(rospy.get_param("datacentre_host"),
-                                               rospy.get_param("datacentre_port") )
+        self._mongo_client=pymongo.Connection(rospy.get_param("datacentre_host"),
+                                              rospy.get_param("datacentre_port") )
 
         # advertise ros services
         for attr in dir(self):

--- a/ros_datacentre/scripts/mongo_bridge.py
+++ b/ros_datacentre/scripts/mongo_bridge.py
@@ -14,6 +14,7 @@ import ros_datacentre.util as dc_util
 from ros_datacentre.srv import *
 import pymongo
 import bson.json_util 
+import json
 
 class MongoBridge(object):
     def __init__(self):
@@ -35,22 +36,22 @@ class MongoBridge(object):
 
     def find_ros_srv(self, req):
         collection = self._mongo_client[req.db][req.collection]
-        res=collection.find(bson.json_util.loads(req.query))
+        res=collection.find(json.loads(req.query, object_hook=json_util.object_hook))
         docs=[i for i in res]
-        return bson.json_util.dumps(docs)
+        return json.dumps(docs, default=json_util.default)
     find_ros_srv.type=MongoFind
 
     def update_ros_srv(self,req):
         collection = self._mongo_client[req.db][req.collection]
-        res=collection.update(bson.json_util.loads(req.query),
-                              bson.json_util.loads(req.update))
-        return bson.json_util.dumps(docs)
+        res=collection.update(json.loads(req.query, object_hook=json_util.object_hook),
+                              json.loads(req.update, object_hook=json_util.object_hook))
+        return json.dumps(docs, default=json_util.default)
     update_ros_srv.type=MongoUpdate
                                                
     def insert_ros_srv(self,req):
         collection = self._mongo_client[req.db][req.collection]
-        res=collection.insert(bson.json_util.loads(req.document))
-        return bson.json_util.dumps(res)
+        res=collection.insert(json.loads(req.document, object_hook=json_util.object_hook))
+        return json.dumps(res, default=json_util.default)
     insert_ros_srv.type=MongoInsert
                                               
 

--- a/ros_datacentre/scripts/mongodb_server.py
+++ b/ros_datacentre/scripts/mongodb_server.py
@@ -13,6 +13,8 @@ import ros_datacentre.util
 
 if not ros_datacentre.util.check_for_pymongo():
     sys.exit(1)
+
+MongoClient = ros_datacentre.util.import_MongoClient()
     
 import pymongo
 
@@ -111,7 +113,7 @@ class MongoServer(object):
             rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
             return
         try:
-            c = pymongo.Connection(self._mongo_host,self._mongo_port)
+            c = MongoClient(self._mongo_host,self._mongo_port)
         except pymongo.errors.ConnectionFailure, c:
             pass
         try:

--- a/ros_datacentre/scripts/mongodb_server.py
+++ b/ros_datacentre/scripts/mongodb_server.py
@@ -111,7 +111,7 @@ class MongoServer(object):
             rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
             return
         try:
-            c = pymongo.MongoClient(self._mongo_host,self._mongo_port)
+            c = pymongo.Connection(self._mongo_host,self._mongo_port)
         except pymongo.errors.ConnectionFailure, c:
             pass
         try:

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -47,7 +47,7 @@ class Replicator(object):
         datacentre_port = rospy.get_param("datacentre_port") 
         master = None
         try:
-            master = pymongo.MongoClient(datacentre_host, datacentre_port)
+            master = pymongo.Connection(datacentre_host, datacentre_port)
         except pymongo.errors.ConnectionFailure, e:
             rospy.logwarn('Could not connect to master datacentre at %s:%s' % (datacentre_host, datacentre_port))
             return None, None
@@ -57,7 +57,7 @@ class Replicator(object):
         extra_clients = []
         for extra in extras:
             try:
-                extra_clients.append(pymongo.MongoClient(extra[0], extra[1]))
+                extra_clients.append(pymongo.Connection(extra[0], extra[1]))
             except pymongo.errors.ConnectionFailure, e:
                 rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
 

--- a/ros_datacentre/scripts/replicator_node.py
+++ b/ros_datacentre/scripts/replicator_node.py
@@ -14,6 +14,9 @@ import subprocess
 from ros_datacentre_msgs.msg import  MoveEntriesAction, MoveEntriesFeedback
 from datetime import *
 
+import ros_datacentre.util
+MongoClient = ros_datacentre.util.import_MongoClient()
+
 class Replicator(object):
     def __init__(self):
 
@@ -47,7 +50,7 @@ class Replicator(object):
         datacentre_port = rospy.get_param("datacentre_port") 
         master = None
         try:
-            master = pymongo.Connection(datacentre_host, datacentre_port)
+            master = MongoClient(datacentre_host, datacentre_port)
         except pymongo.errors.ConnectionFailure, e:
             rospy.logwarn('Could not connect to master datacentre at %s:%s' % (datacentre_host, datacentre_port))
             return None, None
@@ -57,7 +60,7 @@ class Replicator(object):
         extra_clients = []
         for extra in extras:
             try:
-                extra_clients.append(pymongo.Connection(extra[0], extra[1]))
+                extra_clients.append(MongoClient(extra[0], extra[1]))
             except pymongo.errors.ConnectionFailure, e:
                 rospy.logwarn('Could not connect to extra datacentre at %s:%s' % (extra[0], extra[1]))
 

--- a/ros_datacentre/src/ros_datacentre/message_store.py
+++ b/ros_datacentre/src/ros_datacentre/message_store.py
@@ -4,6 +4,7 @@ import ros_datacentre.util as dc_util
 from ros_datacentre_msgs.msg import StringPair, StringPairList, SerialisedMessage
 from bson import json_util
 from bson.objectid import ObjectId
+import json
 import copy
 
 
@@ -87,7 +88,7 @@ class MessageStoreProxy:
 
 		"""
 		# assume meta is a dict, convert k/v to tuple pairs 
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta, default=json_util.default)),)
 		serialised_msg = dc_util.serialise_message(message)
 		return self.insert_srv(self.database, self.collection, serialised_msg, StringPairList(meta_tuple)).id
 
@@ -192,9 +193,9 @@ class MessageStoreProxy:
 		 
 		"""
 		# serialise the json queries to strings using json_util.dumps
-		message_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(message_query)),)
-		meta_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta_query)),)
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta)),)
+		message_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(message_query, default=json_util.default)),)
+		meta_query_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta_query, default=json_util.default)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta, default=json_util.default)),)
 		return self.update_srv(self.database, self.collection, upsert, StringPairList(message_query_tuple), StringPairList(meta_query_tuple), dc_util.serialise_message(message), StringPairList(meta_tuple))		
 
 
@@ -217,8 +218,8 @@ class MessageStoreProxy:
 		# assume meta is a dict, convert k/v to tuple pairs for ROS msg type
 
 		# serialise the json queries to strings using json_util.dumps
-		message_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(message_query)),)
-		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json_util.dumps(meta_query)),)
+		message_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(message_query, default=json_util.default)),)
+		meta_tuple = (StringPair(dc_srv.MongoQueryMsgRequest.JSON_QUERY, json.dumps(meta_query, default=json_util.default)),)
 
 		# a tuple of SerialisedMessages
 		response = self.query_id_srv(self.database, self.collection, type, single, StringPairList(message_tuple), StringPairList(meta_tuple))		

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -42,12 +42,6 @@ def check_for_pymongo():
         print("Can't import pymongo, this is needed by ros_datacentre.")
         print("Make sure it is installed (sudo pip install pymongo)")
         return False
-
-    if not "MongoClient" in dir(pymongo):
-        print ("ERROR!!!")
-        print("Can't import required version of pymongo. We need >= 2.3")
-        print("Make sure it is installed (sudo pip install pymongo) not apt-get")
-        return False
     
     return True
 

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -47,6 +47,27 @@ def check_for_pymongo():
     return True
 
 """
+Pick an object to use as MongoClient based on the currently installed pymongo
+version. Use this instead of importing Connection or MongoClient from pymongo
+directly.
+
+Example:
+    MongoClient = util.importMongoClient()
+"""
+def import_MongoClient():
+    import pymongo
+    if pymongo.version >= '2.4':
+        def mongo_client_wrapper(*args, **kwargs):
+            return pymongo.MongoClient(*args, **kwargs)
+        return mongo_client_wrapper
+    else:
+        import functools
+        def mongo_client_wrapper(*args, **kwargs):
+            return pymongo.Connection(*args, **kwargs)
+        return functools.partial(mongo_client_wrapper, safe=True)
+
+
+"""
 Given a ROS msg and a dictionary of the right values, fill in the msg
 """
 def _fill_msg(msg,dic):

--- a/ros_datacentre/src/ros_datacentre/util.py
+++ b/ros_datacentre/src/ros_datacentre/util.py
@@ -3,6 +3,7 @@ import genpy
 from std_srvs.srv import Empty
 import yaml
 from bson import json_util, Binary
+import json
 
 import copy
 import StringIO
@@ -454,7 +455,7 @@ def string_pair_list_to_dictionary(spl):
     """
     if len(spl.pairs) > 0 and spl.pairs[0].first == MongoQueryMsgRequest.JSON_QUERY:
         # print "looks like %s", spl.pairs[0].second
-        return json_util.loads(spl.pairs[0].second)
+        return json.loads(spl.pairs[0].second, object_hook=json_util.object_hook)
     # else use the string pairs
     else:
         return string_pair_list_to_dictionary_no_json(spl.pairs)


### PR DESCRIPTION
Convert MongoClient to Connection and use old json_utils API for serializing/deserializing data.

This is mainly for convenience so that `rosdep` and friends are still useful when installing from scratch.
