### PR TITLE
Move default parameter store. Closes #71

### DIFF
--- a/ros_datacentre/README.md
+++ b/ros_datacentre/README.md
@@ -45,8 +45,8 @@ The config manager provides a centralised way to store robot application paramet
 Two levels of parameters are considered:
 
 1) Global default parameters. 
-These should be "working defaults" - so all essential parameters at least have a default value. For example, if a robot application requires some calibration data, default values should be provided.
-These parameters are shared among sites, so are stored inside github under ros_datacentre/defaults. When the config manager is started, all .yaml files stored in this folder will be examined. Any new default parameters will be inserted into the "defaults" collection within the configs database.
+These should be "working defaults" - so all essential parameters at least have a default value. For example, if a robot application requires some calibration data then default values should be provided.
+Default parameters can be shared among sites and stored inside a shared ROS package. When the config manager is started, all .yaml files stored in a 'defaults' folder will be examined. Any new default parameters will automatically be inserted into the "defaults" collection within the configs database. The defaults folder should be supplied as a private parameter: `~defaults_path` either set to a system path or in the form `pkg://ros_package_name/inside/package`.
 
 2) Local parameters.
 These parameters override the same named  global default parameters, allowing site-specific parameter setting. They are stored within the database inside the "local" collection.
@@ -63,7 +63,7 @@ To start the config manager, make sure that you have the mongo db running then:
 
 
 ```
-rosrun ros_datacentre config_manager.py
+rosrun ros_datacentre config_manager.py _defaults_path:=pkg://my_package/defaults
 ```
 
 This will load all parameters onto the ros parameter server, which can be checked with:

--- a/ros_datacentre/defaults/README.md
+++ b/ros_datacentre/defaults/README.md
@@ -1,1 +1,0 @@
-Any YAML files in this directory will be read to provide default parameters.

--- a/ros_datacentre/defaults/twitter_params.yaml
+++ b/ros_datacentre/defaults/twitter_params.yaml
@@ -1,5 +1,0 @@
-twitter:
-  appKey: 'vDcKFy7YrG2NNvjvH0BTVQ'
-  appSecret: 'nDynC5hjYqBPW9xEEiULTG4FEHRTdCHTUVClHGu00'
-  oauthToken: '2192647862-uGT366zFzOQgz0W0XoqqG6YIR9HFltYCWZDD07I'
-  oauthTokenSecret: '7ybaYLsFWhbTrRfFlxlIoxQX7SwiZbcmnidaOOgyc41nH'

--- a/ros_datacentre/launch/datacentre.launch
+++ b/ros_datacentre/launch/datacentre.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="db_path" default="/opt/strands/ros_datacentre"/>
   <arg name="port" default="62345" />
+  <arg name="defaults_path" default=""/>
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
 
@@ -13,7 +14,9 @@
     <param name="database_path" value="$(arg db_path)"/>
   </node>
 
-  <node name="config_manager" pkg="ros_datacentre" type="config_manager.py" output="screen"/>
+  <node name="config_manager" pkg="ros_datacentre" type="config_manager.py" output="screen">
+	<param name="defaults_path" value="$(arg defaults_path)"/>
+  </node>
 
   <node name="message_store" pkg="ros_datacentre" type="message_store_node.py" output="screen"/>
 

--- a/ros_datacentre/scripts/config_manager.py
+++ b/ros_datacentre/scripts/config_manager.py
@@ -78,55 +78,83 @@ class ConfigManager(object):
         self._database.add_son_manipulator(MongoTransformer())
 
         # Load the default settings from the defaults/ folder
-        path = os.path.join(roslib.packages.get_pkg_dir('ros_datacentre'),"defaults")
-        files = os.listdir(path)
-        defaults=[]  # a list of 3-tuples, (param, val, originating_filename)
-        def flatten(d, c="", f_name="" ):
-            l=[]
-            for k, v in d.iteritems():
-                if isinstance(v, collections.Mapping):
-                    l.extend(flatten(v,c+"/"+k, f_name))
-                else:
-                    l.append((c+"/"+k, v, f_name))
-            return l
-                             
-        for f in files:
-            if not f.endswith(".yaml"):
-                continue
-            params = rosparam.load_file(os.path.join(path,f))
-            rospy.loginfo("Found default parameter file %s" % f)
-            for p, n in params:
-                defaults.extend(flatten(p,c="",f_name=f))
+        try:
+            path = rospy.get_param("~defaults_path")
+            if len(path)==0:
+                raise 
+        except:
+            rospy.loginfo("Default parameters path not supplied, assuming none.")
+        else:
+            if path.startswith("pkg://"):
+                parts = path.split("//")
+                parts=parts[1].split("/",1)
+                pkg=parts[0]
+                pkg_dir=parts[1]
+                try:
+                    path = os.path.join(roslib.packages.get_pkg_dir(pkg), pkg_dir)
+                except roslib.packages.InvalidROSPkgException, e:
+                    rospy.logerr("Supplied defaults path '%s' cannot be found. \n"%path +
+                                 "The ROS package '%s' could not be located."%pkg)
+                    sys.exit(1)
+            if not os.path.isdir(path):
+                rospy.logwarn("Defaults path '%s' does not exist. Creating it."%path)
+                try:
+                    os.mkdir(path)
+                except:
+                    rospy.logerr("Can't create defaults path '%s"%path)
+                    sys.exit(1)
+            try:
+                files = os.listdir(path)
+            except OSError, e:
+                rospy.logerr("Can't list defaults directory %s. Check permissions."%path)
+                sys.exit(1)
+            defaults=[]  # a list of 3-tuples, (param, val, originating_filename)
+            def flatten(d, c="", f_name="" ):
+                l=[]
+                for k, v in d.iteritems():
+                    if isinstance(v, collections.Mapping):
+                        l.extend(flatten(v,c+"/"+k, f_name))
+                    else:
+                        l.append((c+"/"+k, v, f_name))
+                return l
 
-        # Copy the defaults into the DB if not there already
-        defaults_collection = self._database.defaults
-        for param,val,filename in defaults:
-            existing = defaults_collection.find_one({"path":param}, manipulate=False)
-            if existing is None:
-                rospy.loginfo("New default parameter for %s"%param)
-                defaults_collection.insert({"path":param,
-                                            "value":val,
-                                            "from_file":filename})
-            elif existing["from_file"]!=filename:
-                rospy.logerr("Two defaults parameter files have the same key:\n%s and %s, key %s"%
-                             (existing["from_file"],filename,param))
-                # Delete the entry so that it can be fixed...
-                defaults_collection.remove(existing)
-                rospy.signal_shutdown("Default parameter set error")
-            else: #if str(existing_value) != str(val):
-                existing_value = self._database._fix_outgoing(existing['value'], defaults_collection)
-                for i,j in zip(str(existing_value),str(val)):
-                    if i !=j:
-                        break
-                else:
-                    if len(str(existing_value)) == len(str(val)):
-                        continue
+            for f in files:
+                if not f.endswith(".yaml"):
+                    continue
+                params = rosparam.load_file(os.path.join(path,f))
+                rospy.loginfo("Found default parameter file %s" % f)
+                for p, n in params:
+                    defaults.extend(flatten(p,c="",f_name=f))
 
-                rospy.loginfo("Updating stored default for %s"%param)
-                new={}
-                new.update(existing)
-                new['value']=val
-                defaults_collection.update(existing, new, manipulate=True)
+            # Copy the defaults into the DB if not there already
+            defaults_collection = self._database.defaults
+            for param,val,filename in defaults:
+                existing = defaults_collection.find_one({"path":param}, manipulate=False)
+                if existing is None:
+                    rospy.loginfo("New default parameter for %s"%param)
+                    defaults_collection.insert({"path":param,
+                                                "value":val,
+                                                "from_file":filename})
+                elif existing["from_file"]!=filename:
+                    rospy.logerr("Two defaults parameter files have the same key:\n%s and %s, key %s"%
+                                 (existing["from_file"],filename,param))
+                    # Delete the entry so that it can be fixed...
+                    defaults_collection.remove(existing)
+                    rospy.signal_shutdown("Default parameter set error")
+                else: #if str(existing_value) != str(val):
+                    existing_value = self._database._fix_outgoing(existing['value'], defaults_collection)
+                    for i,j in zip(str(existing_value),str(val)):
+                        if i !=j:
+                            break
+                    else:
+                        if len(str(existing_value)) == len(str(val)):
+                            continue
+
+                    rospy.loginfo("Updating stored default for %s"%param)
+                    new={}
+                    new.update(existing)
+                    new['value']=val
+                    defaults_collection.update(existing, new, manipulate=True)
                 
                 
         # Load the settings onto the ros parameter server

--- a/ros_datacentre/scripts/config_manager.py
+++ b/ros_datacentre/scripts/config_manager.py
@@ -97,12 +97,8 @@ class ConfigManager(object):
                                  "The ROS package '%s' could not be located."%pkg)
                     sys.exit(1)
             if not os.path.isdir(path):
-                rospy.logwarn("Defaults path '%s' does not exist. Creating it."%path)
-                try:
-                    os.mkdir(path)
-                except:
-                    rospy.logerr("Can't create defaults path '%s"%path)
-                    sys.exit(1)
+                rospy.logwarn("Defaults path '%s' does not exist."%path)
+                sys.exit(1)
             try:
                 files = os.listdir(path)
             except OSError, e:


### PR DESCRIPTION
This PR removes the config manager default parameters from this repo and makes the path to the default parameters an optional parameter. If no path is supplied then only local parameters are considered.
