### PR TITLE
add launch as replSet option

### DIFF
--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -6,8 +6,8 @@
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
   <arg name="test_mode" default="false" />
-  <arg name="use_replSet" default="false" />
-  <arg name="replSet" default="rs0" />
+  <arg name="use_repl_set" default="false" />
+  <arg name="repl_set" default="rs0" />
 
 
   <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
@@ -27,7 +27,7 @@
  
 	  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" output="screen">
 	    <param name="database_path" value="$(arg db_path)"/>
-	    <param name="replSet" value="$(arg replSet)" if="$(arg use_replSet)" />
+	    <param name="repl_set" value="$(arg repl_set)" if="$(arg use_repl_set)" />
 	  </node>
 	</group>
 

--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -6,6 +6,8 @@
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
   <arg name="test_mode" default="false" />
+  <arg name="use_replSet" default="false" />
+  <arg name="replSet" default="rs0" />
 
 
   <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
@@ -25,6 +27,7 @@
  
 	  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" output="screen">
 	    <param name="database_path" value="$(arg db_path)"/>
+	    <param name="replSet" value="$(arg replSet)" if="$(arg use_replSet)" />
 	  </node>
 	</group>
 

--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -36,6 +36,7 @@ class MongoServer(object):
 
 
         test_mode = rospy.get_param("~test_mode", False)
+        self.replSet = rospy.get_param("~replSet", None)
 
 
         if test_mode:
@@ -106,8 +107,12 @@ class MongoServer(object):
         def block_mongo_kill():
             os.setpgrp()
 #            signal.signal(signal.SIGINT, signal.SIG_IGN)
-        
-        self._mongo_process = subprocess.Popen(["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port)],
+
+        cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port)]
+        if self.replSet is not None:
+            cmd.append("--replSet")
+            cmd.append(self.replSet)
+        self._mongo_process = subprocess.Popen(cmd,
                                          stdout=subprocess.PIPE,
                                          preexec_fn = block_mongo_kill)
 
@@ -127,6 +132,11 @@ class MongoServer(object):
 
                 if stdout.find("waiting for connections on port") !=-1:
                     self._ready=True
+                    if self.replSet is not None:
+                        try:
+                            self.initialize_repl_set()
+                        except Exception as e:
+                            rospy.logwarn("initialzing replSet failed: %s" % e)
 
         if not rospy.is_shutdown():
             rospy.logerr("MongoDB process stopped!")
@@ -160,7 +170,11 @@ class MongoServer(object):
         while not self._ready:
             rospy.sleep(0.1)
         return EmptyResponse()
-            
+
+    def initialize_repl_set(self):
+        c = pymongo.Connection("%s:%d" % (self._mongo_host,self._mongo_port), slave_okay=True)
+        c.admin.command("replSetInitiate")
+        c.close()
 
 if __name__ == '__main__':
     server = MongoServer()

--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -36,7 +36,7 @@ class MongoServer(object):
 
 
         test_mode = rospy.get_param("~test_mode", False)
-        self.replSet = rospy.get_param("~replSet", None)
+        self.repl_set = rospy.get_param("~repl_set", None)
 
 
         if test_mode:
@@ -109,9 +109,9 @@ class MongoServer(object):
 #            signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port)]
-        if self.replSet is not None:
+        if self.repl_set is not None:
             cmd.append("--replSet")
-            cmd.append(self.replSet)
+            cmd.append(self.repl_set)
         self._mongo_process = subprocess.Popen(cmd,
                                          stdout=subprocess.PIPE,
                                          preexec_fn = block_mongo_kill)
@@ -132,7 +132,7 @@ class MongoServer(object):
 
                 if stdout.find("waiting for connections on port") !=-1:
                     self._ready=True
-                    if self.replSet is not None:
+                    if self.repl_set is not None:
                         try:
                             self.initialize_repl_set()
                         except Exception as e:


### PR DESCRIPTION
I'd like to launch `mongod` process as "Replica Sets" mode for integrating with `elasticsearch`. (e,g, https://github.com/richardwilly98/elasticsearch-river-mongodb)
So I added the option.
