### PR TITLE
allowing to specify start and end datetimes of playback from mongodb

### DIFF
--- a/mongodb_store/scripts/mongodb_play.py
+++ b/mongodb_store/scripts/mongodb_play.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import rospy
 import mongodb_store.util as mg_util
@@ -295,7 +296,7 @@ class MongoPlayback(object):
         else:
             end_time = to_ros_time(mkdatetime(end_dt[0] + ' ' + end_dt[1]))     
 
-        print('Start time: %s, end time: %s' % (to_datetime(start_time), to_datetime(end_time)))
+        #print('Start time: %s, end time: %s' % (to_datetime(start_time), to_datetime(end_time)))
 
 
         # we don't need a connection any more


### PR DESCRIPTION
Title says it - there are now two new datetime parameters: start and end
The mongodb_play will then fetch and replay only data that is between these two datetimes.
