### PR TITLE
Silence wait_for_service.

### DIFF
--- a/mongodb_store/src/mongodb_store/message_store.py
+++ b/mongodb_store/src/mongodb_store/message_store.py
@@ -43,12 +43,21 @@ class MessageStoreProxy:
 		update_service = service_prefix + '/update'
 		delete_service = service_prefix + '/delete'
 		query_ids_service = service_prefix + '/query_messages'
-		rospy.loginfo("Waiting for services...")
-		rospy.wait_for_service(insert_service)
-		rospy.wait_for_service(update_service)
-		rospy.wait_for_service(query_ids_service)
-		rospy.wait_for_service(delete_service)
-		rospy.loginfo("Done")
+                # try and get the mongo service, block until available
+                found_services_first_try = True # if found straight away
+                while True:
+                        try:
+                                rospy.wait_for_service(insert_service,5)
+                                rospy.wait_for_service(update_service,5)
+                                rospy.wait_for_service(query_ids_service,5)
+                                rospy.wait_for_service(delete_service,5)
+                                break
+                        except ROSException, e:
+                                found_services_first_try = False
+                                rospy.logerr("Could not get message store services. Maybe the message "
+                                             "store has not been started? Retrying..")
+                if not found_services_first_try:
+                        rospy.loginfo("Message store services found.")
 		self.insert_srv = rospy.ServiceProxy(insert_service, dc_srv.MongoInsertMsg)
 		self.update_srv = rospy.ServiceProxy(update_service, dc_srv.MongoUpdateMsg)
 		self.query_id_srv = rospy.ServiceProxy(query_ids_service, dc_srv.MongoQueryMsg)


### PR DESCRIPTION
This adds some more helpful output if the messages store services can't be found, but produces no output if they are found within 5 seconds.
