### PR TITLE
[mongodb_store] add limit argument for query

### DIFF
--- a/mongodb_store/include/mongodb_store/message_store.h
+++ b/mongodb_store/include/mongodb_store/message_store.h
@@ -163,20 +163,21 @@ public:
 
 	template<typename MsgType> 
 	bool queryNamed(const std::string & _name, 
-					std::vector< boost::shared_ptr<MsgType> > & _messages, 
-					bool _find_one = true) {
+                        std::vector< boost::shared_ptr<MsgType> > & _messages, 
+                        bool _find_one = true,
+                        int _limit = 0) {
 
 		
 		mongo::BSONObj meta_query = BSON( "name" << _name );
-		return query<MsgType>(_messages, EMPTY_BSON_OBJ, meta_query, _find_one);
+		return query<MsgType>(_messages, EMPTY_BSON_OBJ, meta_query, _find_one, _limit);
 	}
 
 	template<typename MsgType> 
-	std::pair<boost::shared_ptr<MsgType>, mongo::BSONObj> queryNamed(const std::string & _name, bool _find_one = true) {
+          std::pair<boost::shared_ptr<MsgType>, mongo::BSONObj> queryNamed(const std::string & _name, bool _find_one = true, int _limit = 0) {
 
 		std::vector< std::pair<boost::shared_ptr<MsgType>, mongo::BSONObj> > msg_and_metas;
 		mongo::BSONObj meta_query = BSON( "name" << _name );
-		bool result = query(msg_and_metas, EMPTY_BSON_OBJ, meta_query, true, true);
+		bool result = query(msg_and_metas, EMPTY_BSON_OBJ, meta_query, _find_one, true, _limit);
 
 		if(result) {
 			return msg_and_metas[0];
@@ -222,7 +223,8 @@ public:
 				const mongo::BSONObj & _message_query = mongo::BSONObj(),
 				const mongo::BSONObj & _meta_query = mongo::BSONObj(),
 				bool _find_one = false,
-				bool _decode_metas = true) {
+                                bool _decode_metas = true,
+                                int _limit = 0) {
 
 		//Create message with basic fields
   		mongodb_store_msgs::MongoQueryMsg msg;
@@ -230,6 +232,7 @@ public:
   		msg.request.collection = m_collection;
   		msg.request.type = get_ros_type<MsgType>();
   		msg.request.single = _find_one;
+                msg.request.limit = _limit;
   	
 		//if there's no message then no copying is necessary
   		if(!_message_query.isEmpty()) {
@@ -272,11 +275,12 @@ public:
 	bool query(std::vector< boost::shared_ptr<MsgType> > & _messages,
 				const mongo::BSONObj & _message_query = mongo::BSONObj(),
 				const mongo::BSONObj & _meta_query = mongo::BSONObj(),
-				bool _find_one = false) {
+                                bool _find_one = false,
+                                int _limit = 0) {
 
 		// call other query method, but ignore metas
 		std::vector< std::pair<boost::shared_ptr<MsgType>, mongo::BSONObj> > msg_and_metas;
-		bool result = query(msg_and_metas, _message_query, _meta_query, _find_one, false);
+		bool result = query(msg_and_metas, _message_query, _meta_query, _find_one, false, _limit);
 
 		for (typename std::vector< std::pair<boost::shared_ptr<MsgType>, mongo::BSONObj> >::iterator i = msg_and_metas.begin(); i != msg_and_metas.end(); ++i)
 		{

--- a/mongodb_store/scripts/message_store_node.py
+++ b/mongodb_store/scripts/message_store_node.py
@@ -194,13 +194,13 @@ class MessageStore(object):
             except ValueError:
                 sort_query_tuples.append((k,v))
 
-        entries =  dc_util.query_message(collection, obj_query, sort_query_tuples, req.single)
+        entries =  dc_util.query_message(collection, obj_query, sort_query_tuples, req.single, req.limit)
 
         # keep trying clients until we find an answer
         for extra_client in self.extra_clients:
             if len(entries) == 0:
                 extra_collection = extra_client[req.database][req.collection]            
-                entries =  dc_util.query_message(extra_collection, obj_query, sort_query_tuples, req.single)
+                entries =  dc_util.query_message(extra_collection, obj_query, sort_query_tuples, req.single, req.limit)
                 if len(entries) > 0:
                     rospy.loginfo("found result in extra datacentre")             
             else:

--- a/mongodb_store/src/example_mongodb_store_cpp_client.cpp
+++ b/mongodb_store/src/example_mongodb_store_cpp_client.cpp
@@ -73,6 +73,10 @@ int main(int argc, char **argv)
 	{
 		ROS_INFO_STREAM("Got: " << *p);
 	}
+
+        messageStore.query<Pose>(results, mongo::BSONObj(), mongo::BSONObj(), false, 2); // limit=2
+        ROS_INFO_STREAM("Got: " << results.size() << " messages.");
+        
 	
 	messageStore.deleteID(id);
 

--- a/mongodb_store/src/mongodb_store/message_store.py
+++ b/mongodb_store/src/mongodb_store/message_store.py
@@ -125,7 +125,7 @@ class MessageStoreProxy:
 		"""
 		return self.delete_srv(self.database, self.collection, message_id)
 
-	def query_named(self, name, type, single = True, meta = {}):
+	def query_named(self, name, type, single = True, meta = {}, limit = 0):
 		"""
 		Finds and returns the message(s) with the given name.
 		
@@ -134,6 +134,7 @@ class MessageStoreProxy:
 		    | type (str): The type of the stored message.
 		    | single (bool): Should only one message be returned?
 		    | meta (dict): Extra queries on the meta data of the message.
+                    | limit (int): Limit number of return documents
 		:Return:
 		    | message (ROS message), meta (dict): The retrieved message and associated metadata
 		      or *None* if the named message could not be found.
@@ -142,7 +143,7 @@ class MessageStoreProxy:
 		# create a copy as we're modifying it
 		meta_copy = copy.copy(meta)
 		meta_copy["name"] = name
-		return self.query(type, {}, meta_copy, single)
+		return self.query(type, {}, meta_copy, single, [], limit)
 
 	def update_named(self, name, message, meta = {}, upsert = False):
 		"""
@@ -211,7 +212,7 @@ class MessageStoreProxy:
 	"""
 	Returns [message, meta] where message is the queried message and meta a dictionary of meta information. If single is false returns a list of these lists.
 	"""
-	def query(self, type, message_query = {}, meta_query = {}, single = False, sort_query = []):
+	def query(self, type, message_query = {}, meta_query = {}, single = False, sort_query = [], limit=0):
 		"""
 		Finds and returns message(s) matching the message and meta data queries.
 		
@@ -221,6 +222,7 @@ class MessageStoreProxy:
 		    | meta_query (dict): A query to match against the meta data of the message
 		    | sort_query (list of tuple): A query to request sorted list to mongodb module
 		    | single (bool): Should only one message be returned?
+                    | limit (int): Limit number of return documents
 		:Returns:
 		    | [message, meta] where message is the queried message and meta a dictionary of
 		      meta information. If single is false returns a list of these lists.
@@ -236,7 +238,7 @@ class MessageStoreProxy:
 				sort_tuple = []
 
 		# a tuple of SerialisedMessages
-		response = self.query_id_srv(self.database, self.collection, type, single, StringPairList(message_tuple), StringPairList(meta_tuple), StringPairList(sort_tuple))
+		response = self.query_id_srv(self.database, self.collection, type, single, limit, StringPairList(message_tuple), StringPairList(meta_tuple), StringPairList(sort_tuple))
 
 		# print response
 

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -335,7 +335,7 @@ def dictionary_to_message(dictionary, cls):
     fill_message(message, dictionary)
     return message
 
-def query_message(collection, query_doc, sort_query=[], find_one=False):
+def query_message(collection, query_doc, sort_query=[], find_one=False, limit=0):
     """
     Peform a query for a stored messages, returning results in list.
 
@@ -344,6 +344,7 @@ def query_message(collection, query_doc, sort_query=[], find_one=False):
         | query_doc (dict): The MongoDB query to execute
         | sort_query (list of tuple): The MongoDB query to sort
         | find_one (bool): Returns one matching document if True, otherwise all matching.
+        | limit (int): Limits number of return documents. 0 means no limit
     :Returns:
         | dict or list of dict: the MongoDB document(s) found by the query
     """
@@ -360,9 +361,9 @@ def query_message(collection, query_doc, sort_query=[], find_one=False):
             return []
     else:
         if sort_query:
-            return [ result for result in collection.find(query_doc).sort(sort_query) ]
+            return [ result for result in collection.find(query_doc).sort(sort_query).limit(limit) ]
         else:
-            return [ result for result in collection.find(query_doc) ]
+            return [ result for result in collection.find(query_doc).limit(limit) ]
 
 def update_message(collection, query_doc, msg, meta, upsert):
     """

--- a/mongodb_store/tests/message_store_cpp_test.cpp
+++ b/mongodb_store/tests/message_store_cpp_test.cpp
@@ -123,7 +123,18 @@ TEST(ROSDatacentre, cppTest)
 		EXPECT_EQ(0, results.size());
 	}
 
-
+        results.clear();
+        for(int i = 0; i < 100; ++i) {
+          geometry_msgs::Pose p;
+          p.orientation.z = i;
+          messageStore.insert<Pose>(p);
+        }
+        if(messageStore.query<Pose>(results, mongo::BSONObj(), mongo::BSONObj(), false, 10)){
+          EXPECT_EQ(10, results.size());
+        }
+        else {
+          ADD_FAILURE() << "Documents are not limited";
+        }
 }
 
 /**

--- a/mongodb_store/tests/test_messagestore.py
+++ b/mongodb_store/tests/test_messagestore.py
@@ -55,6 +55,11 @@ class TestMessageStoreProxy(unittest.TestCase):
         result = msg_store.query(Pose._type, message_query={ 'orientation.z': {'$gt': 10} }, sort_query=[("$natural", -1)])
         self.assertEqual(len(result), 100)
         self.assertEqual(result[0][0].orientation.x, 99)
+
+        # get documents with limit
+        result_limited = msg_store.query(Pose._type, message_query={'orientation.z': {'$gt': 10} }, sort_query=[("$natural", 1)], limit=10)
+        self.assertEqual(len(result_limited), 10)
+        self.assertListEqual([int(doc[0].orientation.x) for doc in result_limited], range(10))
         
         # must remove the item or unittest only really valid once
         print meta["_id"]

--- a/mongodb_store_msgs/srv/MongoQueryMsg.srv
+++ b/mongodb_store_msgs/srv/MongoQueryMsg.srv
@@ -9,6 +9,8 @@ string collection
 string type
 # whether you're only looking for a single 
 bool single
+# how much messages you want. limit=0 is equivalent to setting no limit.
+uint16 limit
 # key/values to be turned into a query doc on message content
 StringPairList message_query
 # key/values to be turned into a query doc on meta content


### PR DESCRIPTION
Using `limit` option saves message size used in service call and time to wait.
