### PR TITLE
Split mongodb_store launch file into two.

### DIFF
--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -1,54 +1,33 @@
 <launch>
+
+
+  <!-- This is the outer launch file for mongodb_store. It sets a machine tag for the mongodb_store_inc.launch to use. If you already have a machine tag defined, you can call mongodb_store_inc.launch directly and use the machine argument to it.-->
+
   <arg name="db_path" default="/var/local/mongodb_store"/>
   <arg name="port" default="62345" />
   <arg name="defaults_path" default=""/>
   <arg name="replicator_dump_path" default="/tmp/replicator_dumps"/>
   <arg name="use_daemon" default="false" />
 
-  <arg name="use_machine" default="true" />
+
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
   <arg name="test_mode" default="false" />
   <arg name="use_repl_set" default="false" />
   <arg name="repl_set" default="rs0" />
 
+  <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)"/>
 
-  <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"
-           if="$(arg use_machine)"/>
+  <include file="$(find mongodb_store)/launch/mongodb_store_inc.launch">
+    <arg name="db_path" value="$(arg db_path)"/>
+    <arg name="port" value="$(arg port)"/>
+    <arg name="defaults_path" value="$(arg defaults_path)"/>
+    <arg name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
+    <arg name="use_daemon" value="$(arg use_daemon)"/>
+    <arg name="machine" value="$(arg machine)"/>    
+    <arg name="test_mode" value="$(arg test_mode)"/>
+    <arg name="use_repl_set" value="$(arg use_repl_set)"/>
+    <arg name="repl_set" value="$(arg repl_set)"/>
+  </include>
 
-  <param name="mongodb_use_daemon" value="$(arg use_daemon)" />
-  <group if="$(arg use_daemon)">
-    <param name="mongodb_port" value="$(arg port)" />
-    <param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
-  </group>
-  <group unless="$(arg use_daemon)">
-	<!-- launch in test mode -->
-	<group if="$(arg test_mode)">
-		<node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" output="screen">
-			<param name="test_mode" value="true"/>
-		</node>
-	</group>
-
-	<!-- launch in non-test, i.e. normal, mode -->
-	<group unless="$(arg test_mode)">
-		<param name="mongodb_port" value="$(arg port)" />
-		<param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
- 
-	  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" output="screen">
-	    <param name="database_path" value="$(arg db_path)"/>
-	    <param name="repl_set" value="$(arg repl_set)" if="$(arg use_repl_set)" />
-	  </node>
-	</group>
-  </group>
-
-  <node name="config_manager" pkg="mongodb_store" type="config_manager.py" output="screen">
-    <param name="defaults_path" value="$(arg defaults_path)"/>
-  </node>
-
-  <node name="message_store" pkg="mongodb_store" type="message_store_node.py" output="screen"/>
-
-
-  <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" output="screen">
-    <param name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
-  </node>
 </launch>

--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -1,0 +1,51 @@
+<launch>
+
+  <!-- This launch file assumes that the machine tag named with the "machine" arg was set previously. If this is not the case then call mongodb_store.launch instead which will set the machine tag for you. This should typically be called within a larger roslaunch structure. -->
+
+  <arg name="db_path" default="/var/local/mongodb_store"/>
+  <arg name="port" default="62345" />
+  <arg name="defaults_path" default=""/>
+  <arg name="replicator_dump_path" default="/tmp/replicator_dumps"/>
+  <arg name="use_daemon" default="false" />
+
+  <arg name="machine"/>
+  <arg name="test_mode" default="false" />
+  <arg name="use_repl_set" default="false" />
+  <arg name="repl_set" default="rs0" />
+
+  <param name="mongodb_use_daemon" value="$(arg use_daemon)" />
+  <group if="$(arg use_daemon)">
+    <param name="mongodb_port" value="$(arg port)" />
+    <param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
+  </group>
+  <group unless="$(arg use_daemon)">
+  	<!-- launch in test mode -->
+  	<group if="$(arg test_mode)">
+  		<node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" machine="$(arg machine)">
+  			<param name="test_mode" value="true"/>
+  		</node>
+  	</group>
+  	<!-- launch in non-test, i.e. normal, mode -->
+  	<group unless="$(arg test_mode)">
+  		<param name="mongodb_port" value="$(arg port)" />
+  		<param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
+   
+  	  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" machine="$(arg machine)">
+  	    <param name="database_path" value="$(arg db_path)"/>
+  	    <param name="repl_set" value="$(arg repl_set)" if="$(arg use_repl_set)" />
+  	  </node>
+  	</group>
+  </group>
+
+  <node name="config_manager" pkg="mongodb_store" type="config_manager.py" machine="$(arg machine)">
+    <param name="defaults_path" value="$(arg defaults_path)"/>
+  </node>
+
+  <node name="message_store" pkg="mongodb_store" type="message_store_node.py" machine="$(arg machine)"/>
+
+  <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" machine="$(arg machine)">
+    <param name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
+  </node>
+
+</launch>
+


### PR DESCRIPTION
This now provides mongodb_store_inc.launch which assumes that a machine tag has been previously set, and is provided by the machine arg. The original mongodb_store.launch file defines a machine tag then calls the _inc.launch file. This design minimises duplication as far as possible, but is still a bit inelegant. The reason we couldn't do everything with a single file, as discussed in #148, is we can't test whether an argument has been set in roslaunch so we don't know when to define a machine tag ourselves. The additional boolean flag to dictate this definition was not a nice solution either.

This supercedes  #148 

@furushchev please double check that this works for your use case. I assume you will include mongodb_store_inc.launch in your framework and pass the `machine:=XXX` arg to it. 

@Jailander this should work with our setup, although we now are missing the `use_machine` argument as this is assumed to be true in the outer launch file.
