### PR TITLE
[mongodb_store/scripts/mongodb_server.py] connect with localhost when shutdown server

### DIFF
--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -154,7 +154,7 @@ class MongoServer(object):
             rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
             return
         try:
-            c = MongoClient(self._mongo_host,self._mongo_port)
+            c = MongoClient(port=self._mongo_port)
         except pymongo.errors.ConnectionFailure, c:
             pass
         try:


### PR DESCRIPTION
shutdown command is available only when client is connected to localhost.
Otherwise, shutdown command fails with error like below:

`OperationFailure: command SON([('shutdown', 1)]) failed: unauthorized: this command must run from localhost when running db without auth`

In this pull request instead, client is connected to localhost only on shutdown.