### PR TITLE
Support local datacentre timeout

### DIFF
--- a/mongodb_store/scripts/message_store_node.py
+++ b/mongodb_store/scripts/message_store_node.py
@@ -26,6 +26,9 @@ class MessageStore(object):
         use_daemon = rospy.get_param('mongodb_use_daemon', False)
 	# If you want to use a remote datacenter, then it should be set as false
 	use_localdatacenter = rospy.get_param('~mongodb_use_localdatacenter', True)
+	local_timeout = rospy.get_param('~local_timeout', 10)
+        if str(local_timeout).lower() == "none":
+            local_timeout = None
 
 	if use_daemon:
             db_host = rospy.get_param('mongodb_host')
@@ -35,7 +38,8 @@ class MessageStore(object):
                 raise Exception("No Daemon?")
         else:
 	  if use_localdatacenter:
-            have_dc = dc_util.wait_for_mongo()
+            rospy.loginfo('Waiting for local datacentre (timeout: %s)' % str(local_timeout))
+            have_dc = dc_util.wait_for_mongo(local_timeout)
             if not have_dc:
                 raise Exception("No Datacentre?")
           # move these to after the wait_for_mongo check as they may not be set before the db is available

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -34,7 +34,7 @@ def check_connection_to_mongod(db_host, db_port):
         return False
 
 
-def wait_for_mongo():
+def wait_for_mongo(timeout):
     """
     Waits for the mongo server, as started through the mongodb_store/mongodb_server.py wrapper
 
@@ -43,7 +43,7 @@ def wait_for_mongo():
     """
     # Check that mongo is live, create connection
     try:
-        rospy.wait_for_service("/datacentre/wait_ready",10)
+        rospy.wait_for_service("/datacentre/wait_ready", timeout)
     except rospy.exceptions.ROSException, e:
         rospy.logerr("Can't connect to MongoDB server. Make sure mongodb_store/mongodb_server.py node is started.")
         return False


### PR DESCRIPTION
The timeout for the datacentre was hardcoded to 10 seconds. However, in
some environments, for example in a cloud setup, this may not be enough.
Make this configurable and just default to the previous 10 seconds.