### PR TITLE
fixing error with launching mongodb_store

### DIFF
--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -34,7 +34,7 @@ def check_connection_to_mongod(db_host, db_port):
         return False
 
 
-def wait_for_mongo(timeout):
+def wait_for_mongo(timeout=60):
     """
     Waits for the mongo server, as started through the mongodb_store/mongodb_server.py wrapper
 


### PR DESCRIPTION
Hi,

I updated my mongodb_store from indigo-0.1.28 to indigo-0.1.29 and I had an error whenever I ran mongodb_store.launch. The error was
```
Traceback (most recent call last):
  File "/home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/replicator_node.py", line 175, in <module>
    store = Replicator()
  File "/home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/replicator_node.py", line 35, in __init__
    if not mongodb_store.util.wait_for_mongo():
TypeError: wait_for_mongo() takes exactly 1 argument (0 given)
Traceback (most recent call last):
  File "/home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/config_manager.py", line 271, in <module>
    server = ConfigManager()
  File "/home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/config_manager.py", line 80, in __init__
    if not mongodb_store.util.wait_for_mongo():
TypeError: wait_for_mongo() takes exactly 1 argument (0 given)
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/core.py", line 467, in signal_shutdown
    h()
  File "/home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/config_manager.py", line 210, in _on_node_shutdown
    self._mongo_client.disconnect()
AttributeError: 'ConfigManager' object has no attribute '_mongo_client'
[replicator_node-4] process has died [pid 22328, exit code 1, cmd /home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/replicator_node.py __name:=replicator_node __log:=/home/fxj345/.ros/log/8d04c2c0-4dfa-11e7-a452-28d244700d8e/replicator_node-4.log].
log file: /home/fxj345/.ros/log/8d04c2c0-4dfa-11e7-a452-28d244700d8e/replicator_node-4*.log
[config_manager-2] process has died [pid 22326, exit code 1, cmd /home/fxj345/phd_ws/src/mongodb_store/mongodb_store/scripts/config_manager.py __name:=config_manager __log:=/home/fxj345/.ros/log/8d04c2c0-4dfa-11e7-a452-28d244700d8e/config_manager-2.log].
log file: /home/fxj345/.ros/log/8d04c2c0-4dfa-11e7-a452-28d244700d8e/config_manager-2*.log
^C[message_store-3] killing on exit
[mongo_server-1] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
```

So, I did this change to fix the problem.