### PR TITLE
[package.xml] Add link to devel repository

### DIFF
--- a/mongodb_store/package.xml
+++ b/mongodb_store/package.xml
@@ -10,7 +10,7 @@
   <author>Nick Hawes</author>
 
   <url type="website">http://www.ros.org/wiki/mongodb_store</url>
-
+  <url type="repository">https://github.com/strands-project/mongodb_store</url>
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Without this, from [the package's wiki page](http://wiki.ros.org/mongodb_store) there's no way to tell where the repo is.