### PR TITLE
remove mongoclient libs from CMakeLists

### DIFF
--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -151,7 +151,7 @@ if (CATKIN_ENABLE_TESTING)
 
   target_link_libraries(message_store_cpp_test
     message_store 
-  ${MongoClient_LIBRARIES} ${OPENSSL_LIBRARIES} 
+    ${OPENSSL_LIBRARIES} 
     ${catkin_LIBRARIES}
     ${Boost_LIBRARIES}
     gtest


### PR DESCRIPTION
When compiling with it I'd get:

```
Errors     << mongodb_store:cmake /home/bruno/devel_ws/logs/mongodb_store/build.cmake.006.log                                                                                                                                         
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
MongoClient_LIBRARIES
    linked by target "message_store_cpp_test" in directory /home/bruno/devel_ws/src/mongodb_store/mongodb_store

cd /home/bruno/devel_ws/build/mongodb_store; catkin build --get-env mongodb_store | catkin env -si  /usr/bin/cmake /home/bruno/devel_ws/src/mongodb_store/mongodb_store --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/bruno/devel_ws/devel/.private/mongodb_store -DCMAKE_INSTALL_PREFIX=/home/bruno/devel_ws/install; cd -
```