### PR TITLE
mongodb_store: support shapeshifter

### DIFF
--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -4,7 +4,7 @@ project(mongodb_store)
 # include our own cmake files
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
 
-find_package(catkin REQUIRED COMPONENTS roscpp message_generation rospy std_msgs std_srvs mongodb_store_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp message_generation rospy std_msgs std_srvs mongodb_store_msgs topic_tools)
 
 find_package(MongoClient REQUIRED)
 

--- a/mongodb_store/include/mongodb_store/message_store.h
+++ b/mongodb_store/include/mongodb_store/message_store.h
@@ -3,6 +3,7 @@
 
 #include "ros/ros.h"
 #include "ros/console.h"
+#include "topic_tools/shape_shifter.h"
 #include "mongodb_store_msgs/MongoInsertMsg.h"
 #include "mongodb_store_msgs/MongoUpdateMsg.h"
 #include "mongodb_store_msgs/MongoQueryMsg.h"
@@ -33,7 +34,7 @@ void fill_serialised_message(mongodb_store_msgs::SerialisedMessage & _sm,
 								const MsgType & _msg) {
 
 	//record type
-	_sm.type = ros::message_traits::DataType<MsgType>::value();
+	_sm.type = ros::message_traits::datatype(_msg);
 
 	//how long the data will be
 	uint32_t serial_size = ros::serialization::serializationLength(_msg);

--- a/mongodb_store/package.xml
+++ b/mongodb_store/package.xml
@@ -26,6 +26,7 @@
   <build_depend>mongodb</build_depend>
   <build_depend>mongodb-dev</build_depend>
   <build_depend>libssl-dev</build_depend>
+  <build_depend>topic_tools</build_depend>
   <!-- Used for examples -->
   <build_depend>geometry_msgs</build_depend>
 


### PR DESCRIPTION
In C++, `topic_tools/ShapeShifter` is used for the representation like `AnyMsg` in Python.
Before this pull request, message type of `topic_tools/ShapeShifter` is set as `*`, not the original type of message, which causes failure on insertion.

```python
ERROR] [WallTime: 1504084639.503414] bad callback: <bound method MessageStore.insert_ros_msg of <__main__.MessageStore object at 0x7f6dc5adcad0>>
Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rospy/topics.py", line 720, in _invoke_callback
    cb(msg)
  File "/home/furushchev/ros/indigo/src/mongodb_store/mongodb_store/scripts/message_store_node.py", line 83, in insert_ros_msg
    self.insert_ros_srv(msg)
  File "/home/furushchev/ros/indigo/src/mongodb_store/mongodb_store/scripts/message_store_node.py", line 93, in insert_ros_srv
    obj = dc_util.deserialise_message(req.message)
  File "/home/furushchev/ros/indigo/src/mongodb_store/mongodb_store/src/mongodb_store/util.py", line 511, in deserialise_message
    cls_string = type_to_class_string(serialised_message.type)
  File "/home/furushchev/ros/indigo/src/mongodb_store/mongodb_store/src/mongodb_store/util.py", line 464, in type_to_class_string
    cls_string = "%s.msg._%s.%s" % (parts[0], parts[1], parts[1])
IndexError: list index out of range
```

In this pull request, I added special serialization function for `topic_tools/ShapeShifter` using template specialization.
