### PR TITLE
had to add `ca-certificates` as `build_depend`

### DIFF
--- a/libmongocxx_ros/package.xml
+++ b/libmongocxx_ros/package.xml
@@ -45,6 +45,7 @@
   <build_depend>libssl-dev</build_depend>
   <build_depend>boost</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>ca-certificates</build_depend>
   <run_depend>libssl-dev</run_depend>
   <run_depend>boost</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
as the build step (git clone) in the cmake command to build the binary packages failed.

@hawesie this is your birthday present ;-)

The problem was that the binary package wouldn't build as it involved calling git clone which won't work because it can't check the authenticity of github.com without `ca-certificates` being installed at build time.
Please re-release once this is done.

It works on the new build-farm because the build environment always already includes the ca-certificates, but we can't assume it.