### PR TITLE
Support Pymongo 3

### DIFF
--- a/mongodb_store/scripts/config_manager.py
+++ b/mongodb_store/scripts/config_manager.py
@@ -67,7 +67,6 @@ class MongoTransformer(pymongo.son_manipulator.SONManipulator):
 class ConfigManager(object):
     def __init__(self):
         rospy.init_node("config_manager")
-        rospy.on_shutdown(self._on_node_shutdown)
 
         use_daemon = rospy.get_param('mongodb_use_daemon', False)
         db_host = rospy.get_param('mongodb_host')
@@ -81,6 +80,7 @@ class ConfigManager(object):
                 sys.exit(1)
         
         self._mongo_client = MongoClient(db_host, db_port)
+        rospy.on_shutdown(self._on_node_shutdown)
 
         self._database=self._mongo_client.config
         self._database.add_son_manipulator(MongoTransformer())

--- a/mongodb_store/scripts/config_manager.py
+++ b/mongodb_store/scripts/config_manager.py
@@ -207,7 +207,11 @@ class ConfigManager(object):
         
         
     def _on_node_shutdown(self):
-        self._mongo_client.disconnect()
+        try:
+            # PyMongo 2.9 or later
+            self._mongo_client.close()
+        except Exception as e:
+            self._mongo_client.disconnect()
 
     # Could just use the ros parameter server to get the params
     # but one day might not back onto the parameter server...

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -68,9 +68,9 @@ def check_for_pymongo():
     try:
         import pymongo
     except:
-        print("ERROR!!!")
-        print("Can't import pymongo, this is needed by mongodb_store.")
-        print("Make sure it is installed (sudo pip install pymongo)")
+        rospy.logerr("ERROR!!!")
+        rospy.logerr("Can't import pymongo, this is needed by mongodb_store.")
+        rospy.logerr("Make sure it is installed (sudo pip install pymongo)")
         return False
 
     return True

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -22,13 +22,20 @@ def check_connection_to_mongod(db_host, db_port):
     """
     if check_for_pymongo():
         try:
-            from pymongo import Connection
-            Connection(db_host, db_port)
-            return True
-        except Exception as e:
-            print("Error: %s" % str(e))
-            print("Could not connect to mongo server %s:%d" % (db_host, db_port))
-            print("Make sure mongod is launched on your specified host/port")
+            try:
+                # pymongo 2.X
+                from pymongo import Connection
+                Connection(db_host, db_port)
+                return True
+            except:
+                # pymongo 3.X
+                from pymongo import MongoClient
+                client = MongoClient(db_host, db_port, connect=False)
+                result = client.admin.command('ismaster')
+                return True
+        except pymongo.errors.ConnectionFailure:
+            rospy.logerr("Could not connect to mongo server %s:%d" % (db_host, db_port))
+            rospy.logerr("Make sure mongod is launched on your specified host/port")
             return False
     else:
         return False


### PR DESCRIPTION
This pull request contains:
- Fixes https://github.com/strands-project/mongodb_store/issues/196
  - Keeps compatibility with PyMongo 3.X ( c.f. http://api.mongodb.com/python/3.5.1/migrate-to-pymongo3.html ) 
- Minor fix
  - Uses `rospy.logerr` for error log instead of `print` to see error on remote computers
  - `config_manager.py`: Fixed installation of `on_shutdown` handler which prevents function call before assigning class member.