### PR TITLE
Store the updated value to rosparam when calling set_param

### DIFF
--- a/mongodb_store/scripts/config_manager.py
+++ b/mongodb_store/scripts/config_manager.py
@@ -243,6 +243,7 @@ class ConfigManager(object):
             new['_id']=value['_id']
             config_db_local.update(value,new, manipulate=True)
             pass
+        rospy.set_param(new["path"], new["value"])
         return SetParamResponse(True)
 
     # This will take the current value from the rosparam server and save it into the DB


### PR DESCRIPTION
I was a bit surprised when I discovered I needed to restart ROS to see my changes reflected on the ROS parameter server. Is there a good reason not to update it when calling set_param?