### PR TITLE
Use system mongocxx client if possible

### DIFF
--- a/libmongocxx_ros/CMakeLists.txt
+++ b/libmongocxx_ros/CMakeLists.txt
@@ -1,250 +1,81 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(libmongocxx_ros)
 
+find_package(catkin REQUIRED)
 
+# find MongoClient from system first
+# if not found, downloads and compiles from sources
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
+find_package(MongoClient)
+if (MongoClient_FOUND)
+  message(STATUS "Found System MongoClient. Copying them into ROS workspace")
+  add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/include
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CATKIN_DEVEL_PREFIX}/include)
+  add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/include/mongo
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${MongoClient_INCLUDE_DIR}/mongo ${CATKIN_DEVEL_PREFIX}/include/mongo
+    DEPENDS ${CATKIN_DEVEL_PREFIX}/include)
+  add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/include/mongo
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CATKIN_DEVEL_PREFIX}/include/mongo ${PROJECT_SOURCE_DIR}/include/mongo
+    DEPENDS ${CATKIN_DEVEL_PREFIX}/include/mongo)
+  add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/lib
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CATKIN_DEVEL_PREFIX}/lib)
+  add_custom_command(OUTPUT ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so
+    COMMAND ${CMAKE_COMMAND} -E copy ${MongoClient_LIBRARY} ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so
+    DEPENDS ${CATKIN_DEVEL_PREFIX}/lib)
+  add_custom_target(mongocxx
+    DEPENDS
+    ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so
+    ${PROJECT_SOURCE_DIR}/include/mongo
+    ${CATKIN_DEVEL_PREFIX}/include/mongo)
+else()
+  message(STATUS "Not Found System MongoClient. Downloading...")
+  include(ProcessorCount)
+  processorcount(PROCESSOR_COUNT)
+  include(ExternalProject)
+  externalproject_add(mongocxx
+    GIT_REPOSITORY https://github.com/mongodb/mongo-cxx-driver.git
+    GIT_TAG releases/legacy
+    PREFIX "${CMAKE_CURRENT_BINARY_DIR}/mongocxx"
+    BUILD_IN_SOURCE 1
+    UPDATE_COMMAND ""
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND scons -j ${PROCESSOR_COUNT} --ssl --sharedclient --disable-warnings-as-errors --prefix=${CATKIN_DEVEL_PREFIX} install && mkdir -p ${CMAKE_CURRENT_SOURCE_DIR}/include && ${CMAKE_COMMAND} -E copy_directory ${CATKIN_DEVEL_PREFIX}/include ${CMAKE_CURRENT_SOURCE_DIR}/include
+    INSTALL_COMMAND ""
+  )
+endif()
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+# dependencies of MongoClient
+find_package(Boost REQUIRED COMPONENTS system thread program_options filesystem)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-)
-
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-include(ExternalProject)
-
+find_package(OpenSSL REQUIRED)
+# workaround for exposing OpenSSL libraries
+set(OpenSSL_LIBRARIES ${OPENSSL_LIBRARIES})
+set(OpenSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
 
 catkin_package(
-	LIBRARIES mongoclient
-	INCLUDE_DIRS include
-)
-
-ExternalProject_add(mongocxx
-	GIT_REPOSITORY https://github.com/mongodb/mongo-cxx-driver.git
-	GIT_TAG releases/legacy
-	PREFIX "${CMAKE_CURRENT_BINARY_DIR}/mongocxx"
-	BUILD_IN_SOURCE 1
-	#PREFIX mongo_cxx_driver
-	UPDATE_COMMAND ""
-	CONFIGURE_COMMAND ""
-#	CONFIGURE_COMMAND "cp -R ${CMAKE_CURRENT_BINARY_DIR}/mongocxx/include ${libmongocxx_ros_SOURCE_DIR}/include"
-	BUILD_COMMAND scons -j 8 --ssl --sharedclient --disable-warnings-as-errors --prefix=${CATKIN_DEVEL_PREFIX} install && mkdir -p ${CMAKE_CURRENT_SOURCE_DIR}/include &&  cp -R ${CATKIN_DEVEL_PREFIX}/include/. ${CMAKE_CURRENT_SOURCE_DIR}/include
-	INSTALL_COMMAND ""
-	#CONFIGURE_COMMAND "scons -C ${CMAKE_CURRENT_BINARY_DIR}/libmongocxx"
-)
+  LIBRARIES mongoclient
+  INCLUDE_DIRS include
+  DEPENDS Boost OpenSSL)
 
 add_library(mongoclient_imp SHARED IMPORTED)
 set_target_properties(mongoclient_imp PROPERTIES IMPORTED_LOCATION ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so)
 
-#find_library(MCLIB NAMES "libmongoclient.so" PATHS "${CATKIN_DEVEL_PREFIX}/lib")
-#message(STATUS "${MCLIB}")
-
 add_library(mongoclient)
-# ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so)
-add_custom_command( TARGET mongoclient POST_BUILD COMMAND cp ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ )
-set_target_properties(mongoclient PROPERTIES LINKER_LANGUAGE CXX )
-
+add_custom_command(TARGET mongoclient
+  POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/)
+set_target_properties(mongoclient PROPERTIES LINKER_LANGUAGE CXX)
 
 add_dependencies(mongoclient_imp mongocxx)
 add_dependencies(mongoclient mongoclient_imp)
 
-#add_library(mongoclient_ros SHARED src/dummy.cpp)
-#add_dependencies(mongoclient_ros mongoclient)
-
-#target_link_libraries(mongoclient_ros
-#   PUBLIC mongoclient
-#   ${catkin_LIBRARIES}
-#)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-#catkin_package(
-#  INCLUDE_DIRS 
-#  LIBRARIES mongoclient
-#  CATKIN_DEPENDS roscxx
-#  DEPENDS system_lib
-#)
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-)
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/libmongocxx_ros.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/libmongocxx_ros_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
+# Mark executables and/or libraries for installation
 install(TARGETS mongoclient
-   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-#install(FILES 
-#	${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.so
-#	${CATKIN_DEVEL_PREFIX}/lib/libmongoclient.a
-#	DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#)
-
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 # Mark cpp header files for installation
 install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include
   FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
-)
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_libmongocxx_ros.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+  PATTERN ".svn" EXCLUDE)

--- a/libmongocxx_ros/cmake/FindMongoClient.cmake
+++ b/libmongocxx_ros/cmake/FindMongoClient.cmake
@@ -1,0 +1,80 @@
+# - Find MongoClient; NOTE: this is specific to warehouse_ros!
+# 
+# And copied to here from https://raw.githubusercontent.com/ros-planning/warehouse_ros/master/cmake/FindMongoDB.cmake -- thanks :)
+#
+# Find the MongoClient includes and client library
+# This module defines
+#  MongoClient_INCLUDE_DIR, where to find mongo/client/dbclient.h
+#  MongoClient_LIBRARY, the libraries needed to use MongoClient.
+#  MongoClient_FOUND, If false, do not try to use MongoClient.
+#  MongoClient_EXPOSE_MACROS, If true, mongo_ros should use '#define MONGO_EXPOSE_MACROS'
+
+
+
+set(MongoClient_EXPOSE_MACROS "NO")
+
+set(MongoClient_PossibleIncludePaths
+  /usr/include/
+  /usr/local/include/
+  /usr/include/mongo/
+  /usr/local/include/mongo/
+  /opt/mongo/include/
+  $ENV{ProgramFiles}/Mongo/*/include
+  $ENV{SystemDrive}/Mongo/*/include
+  )
+find_path(MongoClient_INCLUDE_DIR mongo/client/dbclient.h
+  ${MongoClient_PossibleIncludePaths})
+
+if(MongoClient_INCLUDE_DIR)
+  find_path(MongoClient_dbclientinterface_Path mongo/client/dbclientinterface.h
+    ${MongoClient_PossibleIncludePaths})
+  if (MongoClient_dbclientinterface_Path)
+    set(MongoClient_EXPOSE_MACROS "YES")
+  endif()
+endif()
+
+if(WIN32)
+  find_library(MongoClient_LIBRARY NAMES mongoclient
+    PATHS
+    $ENV{ProgramFiles}/Mongo/*/lib
+    $ENV{SystemDrive}/Mongo/*/lib
+    )
+else(WIN32)
+  find_library(MongoClient_LIBRARY NAMES mongoclient
+    PATHS
+    /usr/lib
+    /usr/lib64
+    /usr/lib/mongo
+    /usr/lib64/mongo
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/local/lib/mongo
+    /usr/local/lib64/mongo
+    /opt/mongo/lib
+    /opt/mongo/lib64
+    )
+endif(WIN32)
+
+# if we got the mongo stuff, add in the other things we want
+if(MongoClient_LIBRARY)
+  find_package(Boost REQUIRED COMPONENTS system thread program_options filesystem)
+  find_package(OpenSSL REQUIRED)
+  list(APPEND MongoClient_LIBRARIES ${MongoClient_LIBRARY})
+  list(APPEND MongoClient_LIBRARIES ${Boost_LIBRARIES})
+  list(APPEND MongoClient_LIBRARIES ${OPENSSL_LIBRARIES})
+endif(MongoClient_LIBRARY)
+
+if(MongoClient_INCLUDE_DIR AND MongoClient_LIBRARY)
+  set(MongoClient_FOUND TRUE)
+  message(STATUS "Found MongoClient: ${MongoClient_INCLUDE_DIR}, ${MongoClient_LIBRARY}")
+  message(STATUS "MongoClient using new interface: ${MongoClient_EXPOSE_MACROS}")
+else(MongoClient_INCLUDE_DIR AND MongoClient_LIBRARY)
+  set(MongoClient_FOUND FALSE)
+  if (MongoClient_FIND_REQUIRED)
+    message(FATAL_ERROR "MongoClient not found.")
+  else (MongoClient_FIND_REQUIRED)
+    message(STATUS "MongoClient not found.")
+  endif (MongoClient_FIND_REQUIRED)
+endif(MongoClient_INCLUDE_DIR AND MongoClient_LIBRARY)
+
+mark_as_advanced(MongoClient_INCLUDE_DIR MongoClient_LIBRARY MongoClient_EXPOSE_MACROS)

--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mongodb_store)
 
-# include our own cmake files
-#set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/" ${CMAKE_MODULE_PATH})
-
 
 find_package(catkin REQUIRED COMPONENTS roscpp message_generation rospy std_msgs std_srvs mongodb_store_msgs topic_tools libmongocxx_ros)
 


### PR DESCRIPTION
This pull request is for fix the issue #204.
In this pull request, I mainly fixed `CMakeLists.txt` of `libmongocxx_ros` to use system mongocxx client if it is found in system region or download and compile from source otherwise.
In current situation, system mongocxx is used on ubuntu 14.04 and downloaded mongocxx is used on ubuntu 16.04.