### PR TITLE
mongodb_store: encode utf-8 on filling rosmsg

### DIFF
--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -313,7 +313,7 @@ def fill_message(message, document):
                     setattr(message, slot, lst)
             else:
                 if isinstance(value, unicode):
-                    setattr(message, slot, str(value))
+                    setattr(message, slot, value.encode('utf-8'))
                 else:
                     setattr(message, slot, value)
 

--- a/mongodb_store/tests/test_messagestore.py
+++ b/mongodb_store/tests/test_messagestore.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
 import unittest
 import random
 from mongodb_store.message_store import MessageStoreProxy
+from std_msgs.msg import String
 from geometry_msgs.msg import Pose, Point, Quaternion
 import rospy
 
@@ -86,6 +88,18 @@ class TestMessageStoreProxy(unittest.TestCase):
         rospy.sleep(2)
         count_after_insert = len(msg_store.query(Pose._type, meta_query={ "no_wait": True }))
         self.assertTrue(count_after_insert > count_before_insert)
+
+    def test_non_ascii(self):
+        msg_store = MessageStoreProxy()
+        msg = String(data="こんにちは")  # non ascii string
+        doc_id = msg_store.insert(msg)
+
+        try:
+            qmsg, _ = msg_store.query_id(doc_id, String._type)
+            self.assertEqual(msg.data, qmsg.data)
+        except rospy.service.ServiceException:
+            self.fail("non ascii unicode string cannot be queried")
+
 
 if __name__ == '__main__':
     import rostest


### PR DESCRIPTION
Querying messages including non-ascii unicode string inside fails on filling message data from mongodb BSON document with the error like below:

```python
[ERROR] [WallTime: 1517718535.363565] [1498895536.545688] 'ascii' codec can't encode characters in position 7-26: ordinal not in range(128)
```

Since mongodb keeps data only with `utf-8` encoding, I added a code to force encode unicode string as 'utf-8' byte string.