### PR TITLE
Test replication functionality

### DIFF
--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -144,6 +144,7 @@ if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest)
 
   add_rostest(tests/message_store.test)
+  add_rostest(tests/replication.test)
 
   add_executable(message_store_cpp_test tests/message_store_cpp_test.cpp)
 

--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -7,7 +7,7 @@ import os
 import re
 import signal
 import errno
-from std_srvs.srv import *
+from std_srvs.srv import Empty, EmptyResponse
 import shutil
 
 import mongodb_store.util
@@ -156,11 +156,12 @@ class MongoServer(object):
             return
         try:
             c = MongoClient(port=self._mongo_port)
-        except pymongo.errors.ConnectionFailure, c:
-            pass
+        except pymongo.errors.ConnectionFailure:
+            c = None
         try:
-            c.admin.command("shutdown")
-        except pymongo.errors.AutoReconnect, a:
+            if c is not None:
+                c.admin.command("shutdown")
+        except pymongo.errors.AutoReconnect:
             pass
         
         if self.test_mode:  # remove auto-created DB in the /tmp folder

--- a/mongodb_store/scripts/replicator_client.py
+++ b/mongodb_store/scripts/replicator_client.py
@@ -5,29 +5,53 @@
 Provides a service to store ROS message objects in a mongodb database in JSON.
 """
 
+from bson import json_util
+import argparse
 import rospy
 import actionlib
-from mongodb_store_msgs.msg import  MoveEntriesAction, MoveEntriesGoal, StringList
-import sys
+from mongodb_store_msgs.msg import MoveEntriesAction, MoveEntriesGoal
+from mongodb_store_msgs.msg import StringList, StringPair, StringPairList
+from mongodb_store_msgs.srv import MongoQueryMsgRequest
+
 
 def feedback(feedback):
-    print feedback
+    rospy.loginfo(feedback)
+
+
+def parse_args(args):
+    p = argparse.ArgumentParser()
+    p.add_argument('database', type=str,
+                   help='The db to move entries from')
+    p.add_argument('collection', type=str, nargs='+',
+                   help='The collections to move entries from')
+    p.add_argument('--move-before', type=int, default=60*60*24,  # 24 hrs
+                   help='Only entries before rospy.Time.now() - move_before are moved. if 0, all are moved')
+    p.add_argument('--delete-after-move', action='store_true',
+                   help='Delete moved entries after replication')
+    return p.parse_args(args)
+
 
 if __name__ == '__main__':
     rospy.init_node("mongodb_replicator_client")
 
+    args = parse_args(rospy.myargv()[1:])
+
+    # validate parameters
+    if args.move_before < 0:
+        raise ValueError('move_before time must be >= 0')
+    move_before = rospy.Duration(args.move_before)
+    goal = MoveEntriesGoal(
+        database=args.database,
+        collections=StringList(args.collection),
+        move_before=move_before,
+        delete_after_move=args.delete_after_move)
+
+    rospy.loginfo('Moves entries from (db: %s, cols: %s)' % (args.database, args.collection))
+    rospy.loginfo('before time: %s' % (rospy.Time.now() - move_before))
+    rospy.loginfo('delete after move: %s' % args.delete_after_move)
+
     client = actionlib.SimpleActionClient('move_mongodb_entries', MoveEntriesAction)
     client.wait_for_server()
-
-    database = sys.argv[1]
-    collections = sys.argv[2:]
-
-    print database
-    print collections
-
-    # but this is the default anyway
-    twenty_four_hrs_ago = rospy.Duration(60 * 60 * 24)
-    goal = MoveEntriesGoal(database=database, collections=StringList(collections), move_before=twenty_four_hrs_ago, delete_after_move=True)
 
     client.send_goal(goal, feedback_cb=feedback)
     client.wait_for_result()

--- a/mongodb_store/scripts/replicator_client.py
+++ b/mongodb_store/scripts/replicator_client.py
@@ -5,13 +5,11 @@
 Provides a service to store ROS message objects in a mongodb database in JSON.
 """
 
-from bson import json_util
 import argparse
 import rospy
 import actionlib
+from mongodb_store_msgs.msg import StringList
 from mongodb_store_msgs.msg import MoveEntriesAction, MoveEntriesGoal
-from mongodb_store_msgs.msg import StringList, StringPair, StringPairList
-from mongodb_store_msgs.srv import MongoQueryMsgRequest
 
 
 def feedback(feedback):

--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import subprocess
 from mongodb_store_msgs.msg import  MoveEntriesAction, MoveEntriesFeedback
-from datetime import *
+from datetime import datetime
 
 
 import mongodb_store.util

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -43,7 +43,7 @@ def check_connection_to_mongod(db_host, db_port):
         return False
 
 
-def wait_for_mongo(timeout=60):
+def wait_for_mongo(timeout=60, ns="/datacentre"):
     """
     Waits for the mongo server, as started through the mongodb_store/mongodb_server.py wrapper
 
@@ -52,11 +52,11 @@ def wait_for_mongo(timeout=60):
     """
     # Check that mongo is live, create connection
     try:
-        rospy.wait_for_service("/datacentre/wait_ready", timeout)
+        rospy.wait_for_service(ns + "/wait_ready", timeout)
     except rospy.exceptions.ROSException, e:
         rospy.logerr("Can't connect to MongoDB server. Make sure mongodb_store/mongodb_server.py node is started.")
         return False
-    wait = rospy.ServiceProxy('/datacentre/wait_ready', Empty)
+    wait = rospy.ServiceProxy(ns + '/wait_ready', Empty)
     wait()
     return True
 

--- a/mongodb_store/tests/replication.test
+++ b/mongodb_store/tests/replication.test
@@ -1,0 +1,32 @@
+<launch>
+  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py">
+    <rosparam>
+      test_mode: true
+      master: true
+    </rosparam>
+  </node>
+  <node name="message_store" pkg="mongodb_store" type="message_store_node.py"/>
+
+  <node name="mongo_server2" pkg="mongodb_store" type="mongodb_server.py">
+    <remap from="/datacentre/shutdown" to="/datacentre2/shutdown"/>
+    <remap from="/datacentre/wait_ready" to="/datacentre2/wait_ready"/>
+    <rosparam>
+      test_mode: true
+      master: false
+      host: localhost
+      port: 49163
+    </rosparam>
+  </node>
+
+  <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py">
+    <rosparam subst_value="true">
+      replicator_dump_path: $(anon /tmp/replicator_dumps)
+    </rosparam>
+  </node>
+  <rosparam>
+    mongodb_store_extras: [["localhost", 49163]]
+  </rosparam>
+
+  <test test-name="test_replication" pkg="mongodb_store" type="test_replication.py"
+        retry="3" />
+</launch>

--- a/mongodb_store/tests/test_replication.py
+++ b/mongodb_store/tests/test_replication.py
@@ -2,13 +2,20 @@
 # -*- coding: utf-8 -*-
 # Author: furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
+import os
 import pymongo
-import subprocess
 import rospy
+import subprocess
 import unittest
 from mongodb_store.util import import_MongoClient, wait_for_mongo
 from mongodb_store.message_store import MessageStoreProxy
 from geometry_msgs.msg import Wrench
+
+
+def get_script_path():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    pkg_dir = os.path.dirname(test_dir)
+    return os.path.join(pkg_dir, "scripts", "replicator_client.py")
 
 
 class TestReplication(unittest.TestCase):
@@ -35,7 +42,7 @@ class TestReplication(unittest.TestCase):
         # move entries
         rospy.sleep(3)
         retcode = subprocess.check_call([
-            'rosrun', 'mongodb_store', 'replicator_client.py',
+            get_script_path(),
             '--move-before', '0',
             replication_db, replication_col])
         self.assertEqual(retcode, 0, "replicator_client returns code 0")
@@ -49,7 +56,7 @@ class TestReplication(unittest.TestCase):
         data, meta = msg_store.query_named(msg_name, Wrench._type)
         self.assertIsNotNone(data, "entry is still in source")
         retcode = subprocess.check_call([
-            'rosrun', 'mongodb_store', 'replicator_client.py',
+            get_script_path(),
             '--move-before', '0',
             '--delete-after-move',
             replication_db, replication_col])

--- a/mongodb_store/tests/test_replication.py
+++ b/mongodb_store/tests/test_replication.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+import pymongo
+import subprocess
+import rospy
+import unittest
+from mongodb_store.util import import_MongoClient, wait_for_mongo
+from mongodb_store.message_store import MessageStoreProxy
+from geometry_msgs.msg import Wrench
+
+
+class TestReplication(unittest.TestCase):
+    def test_replication(self):
+        replication_db = "replication_test"
+        replication_col = "replication_test"
+        # connect to destination for replication
+        try:
+            self.assertTrue(wait_for_mongo(ns="/datacentre2"), "wait for mongodb server")
+            dst_client = import_MongoClient()("localhost", 49163)
+            count = dst_client[replication_db][replication_col].count()
+            self.assertEqual(count, 0, "No entry in destination")
+        except pymongo.errors.ConnectionFailure:
+            self.fail("Failed to connect to destination for replication")
+
+        # insert an entry to move
+        self.assertTrue(wait_for_mongo(), "wait for mongodb server")
+        msg_store = MessageStoreProxy(
+            database=replication_db, collection=replication_col)
+        msg = Wrench()
+        msg_name = "replication test message"
+        self.assertIsNotNone(msg_store.insert_named(msg_name, msg), "inserted message")
+
+        # move entries
+        rospy.sleep(3)
+        retcode = subprocess.check_call([
+            'rosrun', 'mongodb_store', 'replicator_client.py',
+            '--move-before', '0',
+            replication_db, replication_col])
+        self.assertEqual(retcode, 0, "replicator_client returns code 0")
+
+        # check if replication was succeeded
+        rospy.sleep(3)
+        count = dst_client[replication_db][replication_col].count()
+        self.assertGreater(count, 0, "entry moved to the destination")
+
+        # test deletion after move
+        data, meta = msg_store.query_named(msg_name, Wrench._type)
+        self.assertIsNotNone(data, "entry is still in source")
+        retcode = subprocess.check_call([
+            'rosrun', 'mongodb_store', 'replicator_client.py',
+            '--move-before', '0',
+            '--delete-after-move',
+            replication_db, replication_col])
+        self.assertEqual(retcode, 0, "replicator_client returns code 0")
+        rospy.sleep(3)
+        data, meta = msg_store.query_named("replication test", Wrench._type)
+        self.assertIsNone(data, "moved entry is deleted from source")
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node("test_replication")
+    rostest.rosrun("mongodb_store", "test_replication", TestReplication)


### PR DESCRIPTION
- Use argument parser for `replicator_client.py` keeping back compatibility

  `replicator_client.py` now can takes some optional arguments:
    ```bash
    $ rosrun mongodb_store replicator_client.py
    usage: replicator_client.py [-h] [--move-before MOVE_BEFORE]
                                [--delete-after-move]
                                database collection [collection ...]
    ```

- Added test codes for replication
- Fixed some bugs to test replication
- Fixed for keeping compatibility between `pymongo` 2.X and 3.X