### PR TITLE
Make sure None / null values reaches the parameter server

### DIFF
--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -6,14 +6,14 @@ if(DEFINED ENV{ROS_DISTRO})
   if(NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
     add_compile_options(-std=c++11)
     message(STATUS "Building with C++11 support")
-  else() 
+  else()
     message(STATUS "ROS Indigo: building without C++11 support")
   endif()
 else()
   message(STATUS "Environmental variable ROS_DISTRO not defined, checking OS version")
   file(STRINGS /etc/os-release RELEASE_CODENAME
 		REGEX "VERSION_CODENAME=")
-  if(NOT ${RELEASE_CODENAME} MATCHES "trusty") 
+  if(NOT ${RELEASE_CODENAME} MATCHES "trusty")
     add_compile_options(-std=c++11)
     message(STATUS "OS distro is not trusty: building with C++11 support")
   else()
@@ -80,7 +80,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-  #${MongoClient_INCLUDE_DIR} 
+  #${MongoClient_INCLUDE_DIR}
 )
 
 link_directories(${catkin_LINK_DIRS})
@@ -106,20 +106,20 @@ target_link_libraries(message_store
 # Specify libraries to link a library or executable target against
 target_link_libraries(example_mongodb_store_cpp_client
   message_store
-  #${MongoClient_LIBRARIES}  
-  ${catkin_LIBRARIES}  
+  #${MongoClient_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 target_link_libraries(example_multi_event_log
   message_store
-  #${MongoClient_LIBRARIES}  
-  ${catkin_LIBRARIES}  
+  #${MongoClient_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 target_link_libraries(example_multi_event_log
   message_store
-  #${MongoClient_LIBRARIES}  
-  ${catkin_LIBRARIES}  
+  #${MongoClient_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 
 
@@ -163,17 +163,18 @@ if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest)
 
   add_rostest(tests/message_store.test)
+  add_rostest(tests/config_manager.test)
   add_rostest(tests/replication.test)
 
   add_executable(message_store_cpp_test tests/message_store_cpp_test.cpp)
 
   target_link_libraries(message_store_cpp_test
-    message_store 
-    ${OPENSSL_LIBRARIES} 
+    message_store
+    ${OPENSSL_LIBRARIES}
     ${catkin_LIBRARIES}
     ${Boost_LIBRARIES}
     gtest
-  ) 
+  )
 
   add_rostest(tests/message_store_cpp_client.test)
 

--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -16,7 +16,7 @@ if not mongodb_store.util.check_for_pymongo():
     sys.exit(1)
 
 MongoClient = mongodb_store.util.import_MongoClient()
-    
+
 import pymongo
 
 def is_socket_free(host, port):
@@ -28,8 +28,8 @@ def is_socket_free(host, port):
 class MongoServer(object):
     def __init__(self):
         rospy.init_node("mongodb_server", anonymous=True)#, disable_signals=True)
-      
- 
+
+
         # Has the db already gone down, before the ros node?
         self._gone_down = False
 
@@ -42,8 +42,8 @@ class MongoServer(object):
 
         if self.test_mode:
             import random
-            
-            default_host = "localhost"            
+
+            default_host = "localhost"
             default_port = random.randrange(49152,65535)
 
             count = 0
@@ -52,8 +52,8 @@ class MongoServer(object):
                 count += 1
                 if count > 100:
                     rospy.logerr("Can't find a free port to run the test server on.")
-                    sys.exit(1)                    
-            
+                    sys.exit(1)
+
             self.default_path = "/tmp/ros_mongodb_store_%d" % default_port
             os.mkdir(self.default_path)
         else:
@@ -69,9 +69,9 @@ class MongoServer(object):
             self._mongo_host = rospy.get_param("mongodb_host", default_host)
             rospy.set_param("mongodb_host",self._mongo_host)
             self._mongo_port = rospy.get_param("mongodb_port", default_port)
-            rospy.set_param("mongodb_port",self._mongo_port)            
+            rospy.set_param("mongodb_port",self._mongo_port)
         else:
-            self._mongo_host = rospy.get_param("~host")     
+            self._mongo_host = rospy.get_param("~host")
             self._mongo_port = rospy.get_param("~port")
 
         rospy.loginfo("Mongo server address: "+self._mongo_host+":"+str(self._mongo_port))
@@ -96,12 +96,12 @@ class MongoServer(object):
         self._wait_ready_srv = rospy.Service("/datacentre/wait_ready",Empty,self._wait_ready_srv_cb)
 
         rospy.on_shutdown(self._on_node_shutdown)
-        
+
         # Start the mongodb server
         self._mongo_loop()
 
-        
-        
+
+
     def _mongo_loop(self):
 
         # Blocker to prevent Ctrl-C being passed to the mongo server
@@ -142,7 +142,7 @@ class MongoServer(object):
 
         if not rospy.is_shutdown():
             rospy.logerr("MongoDB process stopped!")
-            
+
         if self._mongo_process.returncode!=0:
             rospy.logerr("Mongo process error! Exit code="+str(self._mongo_process.returncode))
 
@@ -163,7 +163,7 @@ class MongoServer(object):
                 c.admin.command("shutdown")
         except pymongo.errors.AutoReconnect:
             pass
-        
+
         if self.test_mode:  # remove auto-created DB in the /tmp folder
             try:
                 shutil.rmtree(self.default_path)

--- a/mongodb_store/tests/config_manager.test
+++ b/mongodb_store/tests/config_manager.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find mongodb_store)/launch/mongodb_store.launch">
+    <arg name="db_path" value="/tmp" />
+  </include>
+j
+  <!-- rosout and diagnostic topic logger -->
+  <!-- <node name="diagnostics_logger" pkg="strands_diagnostics" type="logger"/> -->
+
+  <test test-name="test_configmanager" pkg="mongodb_store" type="test_configmanager.py" />
+
+</launch>

--- a/mongodb_store/tests/test_configmanager.py
+++ b/mongodb_store/tests/test_configmanager.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+from mongodb_store.srv import SetParam
+import rospy
+
+class TestConfigManager(unittest.TestCase):
+    def test_param_None(self):
+        proxy = rospy.ServiceProxy('/config_manager/set_param', SetParam)
+        proxy.wait_for_service()
+
+        try:
+            result = proxy('{\"path\":\"/chris\",\"value\": null}')
+            self.assertFalse(result.success, "Expected SetParameter to fail when adding None value")
+
+        except rospy.service.ServiceException:
+            self.fail("Should not crash when providing a null value")
+
+
+
+if __name__ == '__main__':
+    import rostest
+    PKG = 'mongodb_store'
+    rospy.init_node('test_config_manager')
+    rostest.rosrun(PKG, 'test_config_manager', TestConfigManager)
+
+


### PR DESCRIPTION
Check the input value to SetParam server, and check the defaults values from yaml-files to make sure null / None values does not reach the parameter server since it does not support it.

This is a problem if you have yaml files without values. The following is a valid yaml file, but will produce an error before this fix.
```yaml
---
my_null_value:
```