### PR TITLE
add method to get num subscribers for insertion

### DIFF
--- a/mongodb_store/include/mongodb_store/message_store.h
+++ b/mongodb_store/include/mongodb_store/message_store.h
@@ -509,7 +509,9 @@ public:
   		return srv.response.success;
 	}
 
-
+  uint32_t getNumInsertSubscribers() const {
+    return m_insertPub.getNumSubscribers();
+  }
 
 protected:
 


### PR DESCRIPTION
This PR adds a method to get number of subscribers for `/message_store/insert` topic.
This number can be used to know if the publisher is advertised and ready to use.