### PR TITLE
Allow to bind mongod to host

### DIFF
--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -16,6 +16,7 @@
   <arg name="use_repl_set" default="false" />
   <arg name="repl_set" default="rs0" />
   <arg name="queue_size" default="100" />
+  <arg name="bind_to_host" default="false" />
 
   <arg name="use_localdatacenter" default="true" />
 
@@ -32,6 +33,7 @@
     <arg name="use_repl_set" value="$(arg use_repl_set)"/>
     <arg name="repl_set" value="$(arg repl_set)"/>
     <arg name="queue_size" value="$(arg queue_size)" />
+    <arg name="bind_to_host" value="$(arg bind_to_host)" />
   </include>
 
 </launch>

--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -13,6 +13,7 @@
   <arg name="use_repl_set" default="false" />
   <arg name="repl_set" default="rs0" />
   <arg name="queue_size" default="100" />
+  <arg name="bind_to_host" default="false" />
 
   <arg name="use_localdatacenter" default="true" />
 
@@ -34,6 +35,7 @@
   		<param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
    
   	  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" machine="$(arg machine)">
+        <param name="bind_to_host" value="$(arg bind_to_host)"/>
   	    <param name="database_path" value="$(arg db_path)"/>
   	    <param name="repl_set" value="$(arg repl_set)" if="$(arg use_repl_set)" />
   	  </node>

--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -38,6 +38,7 @@ class MongoServer(object):
 
         self.test_mode = rospy.get_param("~test_mode", False)
         self.repl_set = rospy.get_param("~repl_set", None)
+        self.bind_to_host = rospy.get_param("~bind_to_host", False)
 
 
         if self.test_mode:
@@ -111,6 +112,11 @@ class MongoServer(object):
 
         #cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port),"--smallfiles","--bind_ip","127.0.0.1"]
         cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port),"--smallfiles"]
+
+        if self.bind_to_host:
+            cmd.append("--bind_ip")
+            cmd.append(self._mongo_host)
+
         if self.repl_set is not None:
             cmd.append("--replSet")
             cmd.append(self.repl_set)


### PR DESCRIPTION
The existing solution bind the mongod server to all interfaces. This
exposes the server to the outside. This could be a potensial security
issue if someone has access to your network. This change allows you
to only bind the server to the host specified by the
`mongodb_host` parameter. The solution was created with a flag
defaulting to false to prevent this from being a breaking change.

Specifying the argument `bind_to_host` will add a bind argument to the
executable:
```
[..., "--bind_ip", self._mongo_host]
```

Info: The `bind_ip` argument [supports hostnames, ipaddresses
and socket
paths](https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-bind-ip)
so using `localhost` or `127.0.0.1` is valid for binding to
localhost only. To bind to all interfaces use `0.0.0.0`.