### PR TITLE
change host into string

### DIFF
--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -131,7 +131,7 @@ class Replicator(object):
                 host, port = extra.address  # pymongo >= 3.0
             except:
                 host, port = extra.host, extra.port
-            rest_args = ['mongorestore',  '--host',  host, '--port',  str(port), self.dump_path]
+            rest_args = ['mongorestore',  '--host',  str(host), '--port',  str(port), self.dump_path]
             self.restore_process = subprocess.Popen(rest_args)
             self.restore_process.wait()
 


### PR DESCRIPTION
I got following error in subprocess in `0.5.1` `melodic`.
This PR prevent this error just changing `host` to `str(host)`
```
[ERROR] [1566054843.135049]: Exception in your execute callback: execv() arg 2 must contain only strings
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
    self.execute_callback(goal)
  File "/opt/ros/melodic/lib/mongodb_store/replicator_node.py", line 110, in move_entries
    self.do_restore(extras, db=goal.database)
  File "/opt/ros/melodic/lib/mongodb_store/replicator_node.py", line 135, in do_restore
    self.restore_process = subprocess.Popen(rest_args)
  File "/usr/lib/python2.7/subprocess.py", line 394, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1047, in _execute_child
    raise child_exception
TypeError: execv() arg 2 must contain only strings
```

```
$ dpkg -l | grep mongodb-store
ii  ros-melodic-mongodb-store                       0.5.1-2bionic.20190628.135820                amd64        A package to support MongoDB-based storage and analysis for data from a ROS system, eg.
ii  ros-melodic-mongodb-store-msgs                  0.5.1-2bionic.20190628.135414                amd64        The mongodb_store_msgs package
```