### PR TITLE
Removed --smallfiles arg no longer supported by MongoDB

### DIFF
--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -114,7 +114,7 @@ class MongoServer(object):
 #            signal.signal(signal.SIGINT, signal.SIG_IGN)
 
         #cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port),"--smallfiles","--bind_ip","127.0.0.1"]
-        cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port),"--smallfiles"]
+        cmd = ["mongod","--dbpath",self._db_path,"--port",str(self._mongo_port)]
 
         if self.bind_to_host:
             cmd.append("--bind_ip")


### PR DESCRIPTION
--smallfiles has been removed and causes the node to crash when run on Ubuntu 18 with the current MongoDB version