### PR TITLE
Added ability for message store to use a full connection string

### DIFF
--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -23,6 +23,9 @@
 
   <arg name="use_localdatacenter" default="true" />
 
+  <arg name="launch_config" default="true" />
+  <arg name="launch_replicator" default="true" />
+
   <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)"/>
 
   <include file="$(find mongodb_store)/launch/mongodb_store_inc.launch">
@@ -38,6 +41,8 @@
     <arg name="repl_set" value="$(arg repl_set)"/>
     <arg name="queue_size" value="$(arg queue_size)" />
     <arg name="bind_to_host" value="$(arg bind_to_host)" />
+    <arg name="launch_config" default="$(arg launch_config)" />
+    <arg name="launch_replicator" default="$(arg launch_replicator)" />
   </include>
 
 </launch>

--- a/mongodb_store/launch/mongodb_store.launch
+++ b/mongodb_store/launch/mongodb_store.launch
@@ -9,6 +9,9 @@
   <arg name="replicator_dump_path" default="/tmp/replicator_dumps"/>
   <arg name="use_daemon" default="false" />
 
+  <!-- Connect via full URI/Connection string. Requires use_daemon to be true -->
+  <arg name="connection_string" default="" />
+
 
   <arg name="machine" default="localhost" />
   <arg name="user" default="" />
@@ -28,6 +31,7 @@
     <arg name="defaults_path" value="$(arg defaults_path)"/>
     <arg name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
     <arg name="use_daemon" value="$(arg use_daemon)"/>
+    <arg name="connection_string" value="$(arg connection_string)"/>
     <arg name="machine" value="$(arg machine)"/>    
     <arg name="test_mode" value="$(arg test_mode)"/>
     <arg name="use_repl_set" value="$(arg use_repl_set)"/>

--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -7,6 +7,9 @@
   <arg name="defaults_path" default=""/>
   <arg name="replicator_dump_path" default="/tmp/replicator_dumps"/>
   <arg name="use_daemon" default="false" />
+  
+  <!-- Connect via full URI/Connection string. Requires use_daemon to be true -->
+  <arg name="connection_string" default="$(arg connection_string)" />
 
   <arg name="machine"/>
   <arg name="test_mode" default="false" />
@@ -18,10 +21,14 @@
   <arg name="use_localdatacenter" default="true" />
 
   <param name="mongodb_use_daemon" value="$(arg use_daemon)" />
+  <param name="mongodb_connection_string" value="$(arg connection_string)" />
+
+
   <group if="$(arg use_daemon)">
     <param name="mongodb_port" value="$(arg port)" />
     <param name="mongodb_host" value="$(optenv ROS_HOSTNAME localhost)" />
   </group>
+
   <group unless="$(arg use_daemon)">
   	<!-- launch in test mode -->
   	<group if="$(arg test_mode)">

--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -7,6 +7,9 @@
   <arg name="defaults_path" default=""/>
   <arg name="replicator_dump_path" default="/tmp/replicator_dumps"/>
   <arg name="use_daemon" default="false" />
+  <arg name="launch_config" default="true" />
+  <arg name="launch_replicator" default="true" />
+
   
   <!-- Connect via full URI/Connection string. Requires use_daemon to be true -->
   <arg name="connection_string" default="$(arg connection_string)" />
@@ -49,18 +52,22 @@
   	</group>
   </group>
 
-  <node name="config_manager" pkg="mongodb_store" type="config_manager.py" machine="$(arg machine)">
-    <param name="defaults_path" value="$(arg defaults_path)"/>
-  </node>
+  <group if="$(arg launch_config)">
+    <node name="config_manager" pkg="mongodb_store" type="config_manager.py" machine="$(arg machine)">
+      <param name="defaults_path" value="$(arg defaults_path)"/>
+    </node>
+  </group>
 
   <node name="message_store" pkg="mongodb_store" type="message_store_node.py" machine="$(arg machine)" > 
 	<param name="mongodb_use_localdatacenter" value="$(arg use_localdatacenter)" />
   <param name="queue_size" value="$(arg queue_size)" />
   </node> <!-- output="screen" -->
 
-  <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" machine="$(arg machine)">
-    <param name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
-  </node>
+  <group if="$(arg launch_replicator)">
+    <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" machine="$(arg machine)">
+      <param name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
+    </node>
+  </group>
 
 </launch>
 

--- a/mongodb_store/scripts/example_message_store_client.py
+++ b/mongodb_store/scripts/example_message_store_client.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         # you don't need a name (note that this p_id is different than one above)
         p_id = msg_store.insert(p)
 
-        p_id = msg_store.insert(['test1', 'test2'])
+        # p_id = msg_store.insert(['test1', 'test2'])
 
         # get it back with a name
         print(msg_store.query_named("my favourite pose", Pose._type))

--- a/mongodb_store/scripts/message_store_node.py
+++ b/mongodb_store/scripts/message_store_node.py
@@ -23,7 +23,6 @@ from mongodb_store_msgs.msg import  StringPair, StringPairList, Insert
 
 MongoClient = dc_util.import_MongoClient()
 
-
 class MessageStore(object):
     def __init__(self, replicate_on_write=False):
 

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -22,7 +22,7 @@ from pymongo.errors import ConnectionFailure
 import importlib
 from datetime import datetime
 
-def check_connection_to_mongod(db_host, db_port):
+def check_connection_to_mongod(db_host, db_port, connection_string=None):
     """
     Check connection to mongod server
 
@@ -39,12 +39,20 @@ def check_connection_to_mongod(db_host, db_port):
             except:
                 # pymongo 3.X
                 from pymongo import MongoClient
-                client = MongoClient(db_host, db_port, connect=False)
+                if connection_string is None:
+                    client = MongoClient(db_host, db_port, connect=False)
+                else:
+                    client = MongoClient(connection_string)
                 result = client.admin.command('ismaster')
                 return True
         except ConnectionFailure:
-            rospy.logerr("Could not connect to mongo server %s:%d" % (db_host, db_port))
-            rospy.logerr("Make sure mongod is launched on your specified host/port")
+            if connection_string is None:
+                rospy.logerr("Could not connect to mongo server %s:%d" % (db_host, db_port))
+                rospy.logerr("Make sure mongod is launched on your specified host/port")
+            else:
+                rospy.logerr("Could not connect to mongo server %s" % (connection_string))
+                rospy.logerr("Make sure mongod is launched on your specified host/port")
+        
             return False
     else:
         return False


### PR DESCRIPTION
I am in the process of moving some of our code to AWS RoboMaker and this will benefit from having an instance of mongodb store running backed by a cloud-based mongodb instance. I have therefore added the ability for this to happen. It's been somewhat hacked in to touch as little of the current code as possible. It works as follows:

```bash
roslaunch mongodb_store mongodb_store.launch use_daemon:=true connection_string:="mongodb+srv://user:pass@cluster0-mongodb.net/test?retryWrites=true&w=majority"
```

Note that if used with this option, the `mongodb_host` and `mongodb_port` ros parameters should not be trusted.
