### PR TITLE
fixed bug in where the replicator node did not recognize the db_host

### DIFF
--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -206,7 +206,7 @@ class Replicator(object):
                 self.connection_string = connection_string
                 is_daemon_alive = mongodb_store.util.check_connection_to_mongod(None, None, connection_string=connection_string)
             else:
-                is_daemon_alive = mongodb_store.util.check_connection_to_mongod(db_host, db_port)
+                 is_daemon_alive = mongodb_store.util.check_connection_to_mongod(self.master_db_host, self.master_db_port)
             if not is_daemon_alive:
                 raise Exception("No Daemon?")
         else:

--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -206,7 +206,7 @@ class Replicator(object):
                 self.connection_string = connection_string
                 is_daemon_alive = mongodb_store.util.check_connection_to_mongod(None, None, connection_string=connection_string)
             else:
-                 is_daemon_alive = mongodb_store.util.check_connection_to_mongod(self.master_db_host, self.master_db_port)
+                is_daemon_alive = mongodb_store.util.check_connection_to_mongod(self.master_db_host, self.master_db_port)
             if not is_daemon_alive:
                 raise Exception("No Daemon?")
         else:


### PR DESCRIPTION
I had an issue in which the db_host was not recognized when running 
`roslaunch mongodb_store mongodb_store.launch host:=localhost use_daemon:=true port:=27017`
The issue was easily fixed by referencing the 'master_db_host' instead of the variable db_host.