### PR TITLE
Added .launch to the roslaunch command in the README.md

### DIFF
--- a/mongodb_store/README.md
+++ b/mongodb_store/README.md
@@ -42,7 +42,7 @@ rosparam set mongodb_use_daemon true
 rosparam set mongodb_port 62345
 rosparam set mongodb_host localhost
 
-roslaunch mongodb_store mongodb_store use_daemon:=true
+roslaunch mongodb_store mongodb_store.launch use_daemon:=true
 ```
 
 Config Manager Overview


### PR DESCRIPTION
Roslaunch takes in two different parameters.

roslaunch <pkg_name> <launch_file>

The launch file must end in .launch for it to be considered an acceptable parameter. 