### PR TITLE
fix connection_string arg default value

### DIFF
--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -12,7 +12,7 @@
 
   
   <!-- Connect via full URI/Connection string. Requires use_daemon to be true -->
-  <arg name="connection_string" default="$(arg connection_string)" />
+  <arg name="connection_string" default="" />
 
   <arg name="machine"/>
   <arg name="test_mode" default="false" />


### PR DESCRIPTION
fix `connection_string` arg default value to `""` in `mongodb_store_inc.launch`