### PR TITLE
handling of host binding

### DIFF
--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -119,6 +119,10 @@ class MongoServer(object):
         if self.bind_to_host:
             cmd.append("--bind_ip")
             cmd.append(self._mongo_host)
+        else:
+            cmd.append("--bind_ip")
+            cmd.append("0.0.0.0")
+            
 
         if self.repl_set is not None:
             cmd.append("--replSet")
@@ -164,7 +168,7 @@ class MongoServer(object):
             rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
             return
         try:
-            c = MongoClient(port=self._mongo_port)
+            c = MongoClient(host=self._mongo_host, port=self._mongo_port)
         except pymongo.errors.ConnectionFailure:
             c = None
         try:


### PR DESCRIPTION
Here is a patch to a common problem:
the mongo process binds to `$HOSTNAME` which may be set to something else than localhost. Then controller here tries to shut it down by connecting to localhost, where it will not be reached and the mongo server process hangs around.
This fixes 2 things:
* ensures the `_mongo_host` is use to trigger the shutdown
* if `bind_to_host` is `False` then it now bind to all interfaces (as one would expect, I'd argue)