### PR TITLE
[mongodb_store] Throttle noisy error log

### DIFF
--- a/mongodb_store/launch/mongodb_store_inc.launch
+++ b/mongodb_store/launch/mongodb_store_inc.launch
@@ -20,6 +20,7 @@
   <arg name="repl_set" default="rs0" />
   <arg name="queue_size" default="100" />
   <arg name="bind_to_host" default="false" />
+  <arg name="logerr_period" default="0" />
 
   <arg name="use_localdatacenter" default="true" />
 
@@ -66,6 +67,7 @@
   <group if="$(arg launch_replicator)">
     <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" machine="$(arg machine)">
       <param name="replicator_dump_path" value="$(arg replicator_dump_path)"/>
+      <param name="logerr_period" value="$(arg logerr_period)"/>
     </node>
   </group>
 

--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -170,11 +170,11 @@ class MongoDumpProcess(MongoProcess):
             query = json_util.dumps(query)
             cmd += ['--query', query]
 
-        super(MongoDumpProcess, self).__init__(cmd=cmd)
+        super(MongoDumpProcess, self).__init__(cmd=cmd, logerr_period=logerr_period)
 
 
 class MongoRestoreProcess(MongoProcess):
-    def __init__(self, host, port, dump_path, db=None, collection=None):
+    def __init__(self, host, port, dump_path, db=None, collection=None, logerr_period=0):
         cmd = [
             'mongorestore', '--verbose', '--host', host, '--port', str(port),
         ]
@@ -183,7 +183,7 @@ class MongoRestoreProcess(MongoProcess):
         if collection is not None:
             cmd += [ '--collection', collection]
         cmd += [dump_path]
-        super(MongoRestoreProcess, self).__init__(cmd=cmd)
+        super(MongoRestoreProcess, self).__init__(cmd=cmd, logerr_period=logerr_period)
 
 
 class Replicator(object):
@@ -317,7 +317,7 @@ class Replicator(object):
             except pymongo.errors.ServerSelectionTimeoutError:
                 rospy.logerr('Failed to connect to the extra server {}'.format(extra))
                 continue
-            self.restore_process = MongoRestoreProcess(host=host, port=port, dump_path=self.dump_path)
+            self.restore_process = MongoRestoreProcess(host=host, port=port, dump_path=self.dump_path, logerr_period=self.logerr_period)
             self.restore_process.start()
             self.restore_process.wait()
             self.restore_process = None

--- a/mongodb_store/scripts/replicator_node.py
+++ b/mongodb_store/scripts/replicator_node.py
@@ -196,7 +196,7 @@ class Replicator(object):
         if use_connection_string:
             use_daemon = True
             rospy.loginfo('Using connection string: %s', connection_string)
-        self.logerr_period = rospy.get_param('logerr_period', 0)
+        self.logerr_period = rospy.get_param('~logerr_period', 0)
 
         self.connection_string = ''
 


### PR DESCRIPTION
The following errors is sometimes output with a very high frequency.
When I parsed log file, 250000 lines error is output for 10000 seconds

```
[ERROR] [1653231340.987602] [/replicator_node:rosout]: [mongorestore] - E11000 duplicate key error collection: jsk_robot_lifelog.fetch1075 index: _id_ dup key: { : ObjectId('6243af9651998d10f0c7787c') }
```

This pull request allows the error log to be output at a specified period.