### PR TITLE
Fix Python 3 bugs in mongodb_store

### DIFF
--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -133,9 +133,18 @@ target_link_libraries(example_multi_event_log
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-install(DIRECTORY scripts/
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-        USE_SOURCE_PERMISSIONS)
+catkin_install_python(PROGRAMS
+  scripts/config_manager.py
+  scripts/example_message_store_client.py
+  scripts/example_multi_event_log.py
+  scripts/message_store_node.py
+  scripts/mongo_bridge.py
+  scripts/mongodb_play.py
+  scripts/mongodb_server.py
+  scripts/replicator_client.py
+  scripts/replicator_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 # Mark other files for installation (e.g. launch and bag files, etc.)
 install(

--- a/mongodb_store/src/mongodb_store/message_store.py
+++ b/mongodb_store/src/mongodb_store/message_store.py
@@ -261,8 +261,8 @@ class MessageStoreProxy:
             messages = []
             metas = []
         else:
-            messages = map(dc_util.deserialise_message, response.messages)
-            metas = map(dc_util.string_pair_list_to_dictionary, response.metas)
+            messages = list(map(dc_util.deserialise_message, response.messages))
+            metas = list(map(dc_util.string_pair_list_to_dictionary, response.metas))
 
         if single:
             if len(messages) > 0:
@@ -270,4 +270,4 @@ class MessageStoreProxy:
             else:
                 return [None, None]
         else:
-            return zip(messages,metas)
+            return list(zip(messages,metas))

--- a/mongodb_store/src/mongodb_store/util.py
+++ b/mongodb_store/src/mongodb_store/util.py
@@ -10,10 +10,10 @@ import copy
 import platform
 if float(platform.python_version()[0:2]) >= 3.0:
     _PY3 = True
-    import io as StringIO
+    from io import BytesIO as Buffer
 else:
     _PY3 = False
-    import StringIO
+    from StringIO import StringIO as Buffer
 from mongodb_store_msgs.msg import SerialisedMessage
 from mongodb_store_msgs.srv import MongoQueryMsgRequest
 
@@ -201,16 +201,13 @@ def sanitize_value(attr, v, type):
         else:
             # ensure unicode
             try:
-                if _PY3:
-                    v = str(v, "utf-8")
-                else:
+                if not _PY3:    # All strings are unicode in Python 3
                     v = unicode(v, "utf-8")
             except UnicodeDecodeError as e:
                 # at this point we can deal with the encoding, so treat it as binary
                 v = Binary(v)
         # no need to carry on with the other type checks below
         return v
-
     if isinstance(v, rospy.Message):
         return msg_to_document(v)
     elif isinstance(v, genpy.rostime.Time):
@@ -332,8 +329,7 @@ def fill_message(message, document):
                     lst.append(msg)
                     setattr(message, slot, lst)
             else:
-                if ( (not _PY3 and isinstance(value, unicode)) or
-                    (_PY3 and isinstance(value, str)) ):
+                if not _PY3 and isinstance(value, unicode):     # All strings are unicode in Python 3
                     setattr(message, slot, value.encode('utf-8'))
                 else:
                     setattr(message, slot, value)
@@ -518,9 +514,9 @@ def serialise_message(message):
     :Args:
         | message (ROS message): The message to serialise
     :Returns:
-        | mongodb_store_msgs.msg.SerialisedMessage: A serialies copy of message
+        | mongodb_store_msgs.msg.SerialisedMessage: A serialised copy of message
     """
-    buf=StringIO.StringIO()
+    buf = Buffer()
     message.serialize(buf)
     serialised_msg = SerialisedMessage()
     serialised_msg.msg = buf.getvalue()

--- a/mongodb_store/tests/test_messagestore.py
+++ b/mongodb_store/tests/test_messagestore.py
@@ -63,19 +63,16 @@ class TestMessageStoreProxy(unittest.TestCase):
         # get documents with limit
         result_limited = msg_store.query(Pose._type, message_query={'orientation.z': {'$gt': 10} }, sort_query=[("$natural", 1)], limit=10)
         self.assertEqual(len(result_limited), 10)
-        self.assertListEqual([int(doc[0].orientation.x) for doc in result_limited], range(10))
+        self.assertListEqual([int(doc[0].orientation.x) for doc in result_limited], list(range(10)))
 
-	#get documents without "orientation" field
-	result_no_id = msg_store.query(Pose._type, message_query={}, projection_query={"orientation": 0})
+        #get documents without "orientation" field
+        result_no_id = msg_store.query(Pose._type, message_query={}, projection_query={"orientation": 0})
         for doc in result_no_id:
-		self.assertEqual(int(doc[0].orientation.z),0 )
-
-
-
+            self.assertEqual(int(doc[0].orientation.z), 0)
 
         # must remove the item or unittest only really valid once
-        print meta["_id"]
-        print str(meta["_id"])
+        print(meta["_id"])
+        print(str(meta["_id"]))
         deleted = msg_store.delete(str(meta["_id"]))
         self.assertTrue(deleted)
 


### PR DESCRIPTION
After some experimentation in ROS Noetic, a couple of bugs related to Python 3 were found. This PR addresses those bugs:

1. Install Python scripts with `catkin_install_python` in `CMakeLists.txt`: 
This makes sure we can run the nodes with `#!/usr/bin/env python` shebangs in ROS Noetic.
2. Explicitly cast `map` and `zip` to `list`: 
In Python 3, `map()` and `zip()` do not return `list` object types (like they do in Python 2). Some other functions in `mongodb_store` assume the `list` type, so we cast them to `list` explicitly.
3. Change buffer type for message serialization in Python 3:
In Python 2, `StringIO` can handle bytes. In Python 3, we need to use a different `IO` in message serialization.
4. Remove explicit string encoding in Python 3:
In Python 2, strings and byte strings are both of type `str`. In Python 3, `str` and `bytes` are different, incompatible types. This means that it is an error if we try to (re-)encode a `str`: `str('a', 'utf-8')`.
5. Fix indentation, spaces, and types in the test file:
The test file had some issues like inconsistent indentation, `print` statements with spaces, and a `range` object treated as a `list`.

The applied changes should have no effect on `mongodb_store` in Python 2.

I'm making this PR into `melodic-devel`, since `noetic-devel` does not exist yet (and as far as I know it's not possible to make a PR for a non-existing branch).