### PR TITLE
Ensure Python 3 compatibility in mongodb log

### DIFF
--- a/mongodb_log/CMakeLists.txt
+++ b/mongodb_log/CMakeLists.txt
@@ -138,7 +138,7 @@ target_link_libraries(mongodb_log_cimg
 
 ## Mark executable scripts (Python etc.) for installation
 ## in contrast to setup.py, you can choose the destination
-install(PROGRAMS
+catkin_install_python(PROGRAMS
   scripts/mongodb_log.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/mongodb_log/scripts/mongodb_log.py
+++ b/mongodb_log/scripts/mongodb_log.py
@@ -46,7 +46,10 @@ import signal
 import subprocess
 from threading import Thread, Timer
 
-from Queue import Empty
+try: 
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 from optparse import OptionParser
 from tempfile import mktemp
 from datetime import datetime, timedelta
@@ -271,12 +274,12 @@ class WorkerProcess(object):
 
                         mongodb_store.util.store_message(self.collection, msg, meta)
 
-                    except InvalidDocument, e:
+                    except InvalidDocument as e:
                         print("InvalidDocument " + current_process().name + "@" + topic +": \n")
-                        print e
-                    except InvalidStringData, e:
+                        print(e)
+                    except InvalidStringData as e:
                         print("InvalidStringData " + current_process().name + "@" + topic +": \n")
-                        print e
+                        print(e)
 
             else:
                 #print("Quit W2: %s" % self.name)
@@ -447,7 +450,7 @@ class MongoWriter(object):
                 self.workers.append(w)
                 self.collnames |= set([collname])
                 self.topics |= set([topic])
-            except Exception, e:
+            except Exception as e:
                 print('Failed to subscribe to %s due to %s' % (topic, e))
                 missing_topics.add(topic)
 
@@ -457,7 +460,7 @@ class MongoWriter(object):
     def create_worker(self, idnum, topic, collname):
         try:
             msg_class, real_topic, msg_eval = rostopic.get_topic_class(topic, blocking=False)
-        except Exception, e:
+        except Exception as e:
             print('Topic %s not announced, cannot get type: %s' % (topic, e))
             raise
 

--- a/mongodb_log/test/test_publisher.py
+++ b/mongodb_log/test/test_publisher.py
@@ -45,6 +45,6 @@ if __name__ == '__main__':
 
     for target in to_publish:
         msg_store = MessageStoreProxy(database='roslog', collection=target[0])
-        print len(msg_store.query(Int64._type)) == target[3]
+        print(len(msg_store.query(Int64._type)) == target[3])
         
 


### PR DESCRIPTION
The `mongodb_log` had some statements specific for Python 2.

This PR makes them compatible with Python 3.