### PR TITLE
Avoid deadlock on server shutdown

### DIFF
--- a/mongodb_store/scripts/mongodb_server.py
+++ b/mongodb_store/scripts/mongodb_server.py
@@ -160,10 +160,10 @@ class MongoServer(object):
             rospy.logerr("Mongo process error! Exit code="+str(self._mongo_process.returncode))
 
         self._gone_down = True
-        self._ready=False
 
     def _on_node_shutdown(self):
         rospy.loginfo("Shutting down datacentre")
+        self._ready=False
         if self._gone_down:
             rospy.logwarn("It looks like Mongo already died. Watch out as the DB might need recovery time at next run.")
             return

--- a/mongodb_store/tests/config_manager.test
+++ b/mongodb_store/tests/config_manager.test
@@ -1,8 +1,8 @@
 <launch>
   <include file="$(find mongodb_store)/launch/mongodb_store.launch">
-    <arg name="db_path" value="/tmp" />
+    <arg name="test_mode" value="true"/>
   </include>
-j
+
   <!-- rosout and diagnostic topic logger -->
   <!-- <node name="diagnostics_logger" pkg="strands_diagnostics" type="logger"/> -->
 


### PR DESCRIPTION
# Summary
This PR solves the issue of deadlock during concurrent shutdown of `mongo_server` and `config_manager` nodes. I came across this issue while running pre-release tests.

This solution is still up for debate (see Question section at the bottom).

# Steps to Reproduce
1. Clone and build the `mongodb_store` package on ROS Noetic or Melodic.
2. Run the `config_manager.test` a couple of times:  
`rostest mongodb_store config_manager.test --text`

In some cases, the `mongo_server` node hangs during shutdown and requires `SIGKILL` to exit (after ~20 seconds). This behavior causes pre-release tests to fail due to timeout.

# Cause
During shutdown, the `mongo_server` issues a `shutdown` command to its `mongod` subprocess. At the same time, the `config_manager` attempts to close its `MongoClient`, which sends some cleanup commands to the `mongod` server. This somehow causes a deadlock and prevents the `mongo_server` node to exit cleanly. In fact, any concurrent command to the `mongod` process during shutdown seems to cause the deadlock.

# Current Solution
This was solved by controlling the node shutdown sequence through the `ready` flag in the `mongodb_server.py` (see commit).

# Question
Several other nodes create `MongoClient` instances and do not close them (`mongodb_store_node`, `replicator_node`, etc.). 
So here we have two options:
1. Include the `MongoClient` closing/cleanup into all the other nodes instantiating it, through `rospy.on_shutdown` (like we now have in the `config_manager` node).
2. Remove the `MongoClient` closing/cleanup from the `config_manager` node, as is the case in other nodes. Resources in the node are freed anyway when it is shut down, and the daemon should [periodically clean up expired sessions](https://github.com/mongodb/mongo/blob/master/src/mongo/db/s/README.md#logical-sessions).

What do you think?