### PR TITLE
Fix documentation to query from extra servers

### DIFF
--- a/mongodb_store/README.md
+++ b/mongodb_store/README.md
@@ -141,7 +141,7 @@ mongodb_store_extras: [["localhost", 62344], ["localhost", 62333]]
 
 Inserts and updates are performed acorss the main and replicant datacentres.
 
-If `mongodb_store_extras` is set (regardless of `replicate_on_write`), queries are performed on the main first, and if nothing found, the replicants are tried.
+If `mongodb_store_extras` is set and `replicate_on_write`is True, queries are performed on the main first, and if nothing found, the replicants are tried.
 
 You can launch additional datacentres as follows, e.g.
 


### PR DESCRIPTION
https://github.com/strands-project/mongodb_store/pull/214 changes default behavior of query when `mongodb_store_extras` is provided. Now we need to set `replicate_on_write` to True to enable this feature.