### PR TITLE
[ROS-O] drastically simplify explicit c++11 check

### DIFF
--- a/mongodb_log/CMakeLists.txt
+++ b/mongodb_log/CMakeLists.txt
@@ -1,24 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mongodb_log)
 
-# for ROS indigo build without C++11 support
-# for ROS indigo compile without c++11 support
 if(DEFINED ENV{ROS_DISTRO})
-  if(NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
+  if($ENV{ROS_DISTRO} STREQUAL "kinetic")
     add_compile_options(-std=c++11)
-    message(STATUS "Building with C++11 support")
-  else() 
-    message(STATUS "ROS Indigo: building without C++11 support")
-  endif()
-else()
-  message(STATUS "Environmental variable ROS_DISTRO not defined, checking OS version")
-  file(STRINGS /etc/os-release RELEASE_CODENAME
-		REGEX "VERSION_CODENAME=")
-  if(NOT ${RELEASE_CODENAME} MATCHES "trusty") 
-    add_compile_options(-std=c++11)
-    message(STATUS "OS distro is not trusty: building with C++11 support")
-  else()
-    message(STATUS "Ubuntu Trusty: building without C++11 support")
+    message(STATUS "Building explicitly with C++11 support")
   endif()
 endif()
 

--- a/mongodb_store/CMakeLists.txt
+++ b/mongodb_store/CMakeLists.txt
@@ -1,23 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mongodb_store)
 
-# for ROS indigo compile without c++11 support
 if(DEFINED ENV{ROS_DISTRO})
-  if(NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
+  if($ENV{ROS_DISTRO} STREQUAL "kinetic")
     add_compile_options(-std=c++11)
-    message(STATUS "Building with C++11 support")
-  else()
-    message(STATUS "ROS Indigo: building without C++11 support")
-  endif()
-else()
-  message(STATUS "Environmental variable ROS_DISTRO not defined, checking OS version")
-  file(STRINGS /etc/os-release RELEASE_CODENAME
-		REGEX "VERSION_CODENAME=")
-  if(NOT ${RELEASE_CODENAME} MATCHES "trusty")
-    add_compile_options(-std=c++11)
-    message(STATUS "OS distro is not trusty: building with C++11 support")
-  else()
-    message(STATUS "Ubuntu Trusty: building without C++11 support")
+    message(STATUS "Building explicitly with C++11 support")
   endif()
 endif()
 


### PR DESCRIPTION
Required to build on Ubuntu 22.04 and newer systems.

[#222, #223, #224] introduced the additional logic dropped here, where the last messages clearly describe that the os detection is not needed.

I would have just dropped the whole block, but as JSK's group is involved here and I know some people like to keep old ROS versions theoretically supported, I changed the check to only add c++11 explicitly back in kinetic (as `melodic` already defaults to 14).

The whole change is needed because Ubuntu 22.04 onwards provide a log4cxx which requires c++17, breaking [this assumption](https://github.com/strands-project/mongodb_store/pull/223#issuecomment-391106697).